### PR TITLE
refactor/bump_requests

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 mycroft-messagebus-client~=0.9.1,!=0.9.2,!=0.9.3
 inflection~=0.3
 pexpect~=4.8
-requests~=2.25
+requests>=2.26.0
 json_database~=0.5
 kthread~=0.2
 pyxdg~=0.26


### PR DESCRIPTION
bump min version to avoid GPL transient dependency (chardet)

companion PR to https://github.com/OpenVoiceOS/ovos-core/pull/52 