### PR TITLE
Fix/full lang

### DIFF
--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -13,7 +13,7 @@ from ovos_utils.xdg_utils import (
 )
 
 try:
-    from lingua_franca.lang import get_default_lang as _lf_get_default_lang
+    from lingua_franca import get_default_loc as _lf_get_default_lang
 except ImportError:
     _lf_get_default_lang = None
 


### PR DESCRIPTION
#47 is using wrong LF method and not returning the full lang code

this causes issues when 4 letter code is expected https://github.com/OpenVoiceOS/ovos-core/runs/6707898606?check_suite_focus=true

this PR makes the default_lang use the proper LF method and return a full lang code