### PR TITLE
fix/screen_check

### DIFF
--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -199,8 +199,18 @@ def is_installed(executable):
 
 def has_screen():
     have_display = "DISPLAY" in os.environ
+    # X server not running
     if not have_display:
-        # fallback check using matplotlib if available
+        # raspberry pi specific check
+        try:
+            have_display = b"device_name=" in subprocess.check_output("tvservice -n 2>&1", shell=True)
+        except Exception as e:
+            pass
+        
+    # fallback check using matplotlib if available
+    # seems to be foolproof and OS agnostic 
+    # but do not want to drag the dependency
+    if not have_display:
         try:
             import matplotlib.pyplot as plt
             try:


### PR DESCRIPTION
in systems without X server running and without matplotlib this method wrongly reports no screen

add an extra check for raspberry devices, this fixes the issue in OpenVoiceOS image at least, further improvements should be investigated