### PR TITLE
Add method to restart arbitrary systemd service

### DIFF
--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -77,8 +77,10 @@ def ssh_disable():
     subprocess.call('sudo systemctl stop ssh.service', shell=True)
     subprocess.call('sudo systemctl disable ssh.service', shell=True)
 
-def restart_mycroft_service():
-    subprocess.call('sudo systemctl restart mycroft.service', shell=True)
+
+def restart_mycroft_service(service_name="mycroft.service"):
+    subprocess.call(f'sudo systemctl restart {service_name}', shell=True)
+
 
 # platform fingerprinting
 def set_root_path(path):

--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -78,7 +78,18 @@ def ssh_disable():
     subprocess.call('sudo systemctl disable ssh.service', shell=True)
 
 
-def restart_mycroft_service(service_name="mycroft.service"):
+def restart_mycroft_service():
+    """
+    Restarts the `mycroft.service` systemd service
+    """
+    restart_service("mycroft.service")
+
+
+def restart_service(service_name):
+    """
+    Restarts a systemd service using systemctl
+    @param service_name: name of service to restart
+    """
     subprocess.call(f'sudo systemctl restart {service_name}', shell=True)
 
 


### PR DESCRIPTION
Extends change from https://github.com/OpenVoiceOS/ovos_utils/pull/61 to restart an arbitrary service. I'll have another PR to the system plugin to read the system service name from config so the restart button can work under different images