### PR TITLE
new intent service/pipeline api

### DIFF
--- a/ovos_utils/__init__.py
+++ b/ovos_utils/__init__.py
@@ -29,6 +29,10 @@ from ovos_utils.network_utils import get_ip, get_external_ip, is_connected_dns, 
 def backwards_compat(classic_core=None, pre_008=None, no_core=None):
     """
     Decorator to run a different method if specific ovos-core versions are detected
+
+    classic_core - mycroft-core latest dev branch (abandonware)
+    pre_008 - marked by introduction of ovos_core module, introduces transformer and pipeline plugins
+    no_core - skills running standalone via ovos-workshop, eg, ovos-docker, unknown what core version it is connected to
     """
 
     def backwards_compat_decorator(func):


### PR DESCRIPTION
moves the backwards_compat decorator from ovos-workshop to also be used here

companion to https://github.com/OpenVoiceOS/ovos-core/pull/349 + https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/177

TODO - document new bus events properly from pipeline plugins 

```
# NOTE: these receive skill_id/name separately, not as part of munged names
  self.bus.on('intent.service:detach_intent', self.handle_detach_intent)
  self.bus.on('intent.service:detach_entity', self.handle_detach_entity)
  self.bus.on('intent.service:detach_skill', self.handle_detach_skill)
  self.bus.on('intent.service.register_intent', self.handle_register_intent)
  self.bus.on('intent.service.register_keyword_intent', self.handle_register_keyword_intent)
  self.bus.on('intent.service.register_regex_intent', self.handle_register_regex_intent)
  self.bus.on('intent.service:register_keyword', self.handle_register_keyword)
  self.bus.on('intent.service:register_entity', self.handle_register_entity)
  self.bus.on('intent.service:register_regex_entity', self.handle_register_regex_entity)
  self.bus.on('intent.service:train', self.handle_train)
```

compatibility with the previous api provided via @backwards_compat decorator
```
  # backwards compat handlers with adapt/padatious namespace
# NOTE: these receive munged intents, skill_id/name need to be extracted from name
  self.bus.on('padatious:register_intent', self.handle_register_intent)
  self.bus.on('padatious:register_entity', self.handle_register_entity)
  self.bus.on('register_vocab', self._handle_adapt_vocab)
  self.bus.on('register_intent', self.handle_register_keyword_intent)
  self.bus.on('detach_intent', self.handle_detach_intent)
  self.bus.on('detach_skill', self.handle_detach_skill)
  self.bus.on('mycroft.skills.initialized', self.handle_train)
```