### PR TITLE
fix: make orjson optional

### DIFF
--- a/ovos_utils/__init__.py
+++ b/ovos_utils/__init__.py
@@ -49,7 +49,7 @@ def json_dumps(payload: Any) -> str:
         # handle dataclasses
         if dataclasses.is_dataclass(payload):
             payload = dataclasses.asdict(payload)
-        return json.dumps(payload)
+        return json.dumps(payload, ensure_ascii=False)
     else:
         # orjson.dumps has native dataclass support and returns bytes
         return orjson.dumps(payload).decode("utf-8")

--- a/ovos_utils/__init__.py
+++ b/ovos_utils/__init__.py
@@ -10,15 +10,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import dataclasses
 import datetime
+import json
 import warnings
 from time import sleep
+from typing import Dict, Any
 
 from ovos_utils.decorators import classproperty, timed_lru_cache
 from ovos_utils.list_utils import flatten_list, rotate_list
 from ovos_utils.log import LOG, log_deprecation
 from ovos_utils.text_utils import camel_case_split
 from ovos_utils.thread_utils import wait_for_exit_signal, threaded_timeout, create_killable_daemon, create_daemon
+
+try:
+    import orjson
+except ImportError:
+    orjson = None
+
+
+def json_dumps(payload: Any) -> str:
+    """
+    Serializes an object to a JSON string using `orjson` if available,
+    with a fallback to the standard `json` library.
+
+    This function provides a significant performance boost when `orjson` is
+    installed, while ensuring compatibility by gracefully falling back. It also
+    handles dataclass serialization for both implementations.
+
+    Args:
+        payload (Any): The object to be serialized. This can be a built-in
+                       type, a dictionary, or a dataclass instance.
+
+    Returns:
+        str: The serialized JSON string.
+    """
+    if orjson is None:
+        # handle dataclasses
+        if dataclasses.is_dataclass(payload):
+            payload = dataclasses.asdict(payload)
+        return json.dumps(payload)
+    else:
+        # orjson.dumps has native dataclass support and returns bytes
+        return orjson.dumps(payload).decode("utf-8")
+
+
+def json_loads(payload: str) -> Dict[str, Any]:
+    """
+    Deserializes a JSON string into a dictionary using `orjson` if available,
+    with a fallback to the standard `json` library.
+
+    This function provides a significant performance boost for deserialization
+    when `orjson` is installed.
+
+    Args:
+        payload (str): The JSON string to be deserialized.
+
+    Returns:
+        Dict[str, Any]: The deserialized data as a dictionary.
+    """
+    if orjson is None:
+        return json.loads(payload)
+    else:
+        return orjson.loads(payload)
 
 
 def create_loop(target, interval, args=(), kwargs=None):

--- a/ovos_utils/ocp.py
+++ b/ovos_utils/ocp.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import Optional, Tuple, List, Union
 import warnings
-import orjson
+from ovos_utils import json_dumps, json_loads
 
 from ovos_utils.log import LOG, deprecated
 
@@ -228,8 +228,8 @@ class MediaEntry:
         """
         Return a dict representation of this MediaEntry
         """
-        # orjson handles dataclasses directly
-        return orjson.loads(orjson.dumps(self).decode("utf-8"))
+        # json_dumps handles dataclasses directly
+        return json_loads(json_dumps(self))
 
     @staticmethod
     def from_dict(track: dict) -> 'MediaEntry':
@@ -326,8 +326,8 @@ class PluginStream:
         """
         Return a dict representation of this MediaEntry
         """
-        # orjson handles dataclasses directly
-        return orjson.loads(orjson.dumps(self).decode("utf-8"))
+        # json_dumps handles dataclasses directly
+        return json_loads(json_dumps(self))
 
     @staticmethod
     def from_dict(track: dict) -> 'PluginStream':

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -6,3 +6,4 @@ ovos_bus_client>=0.0.8
 langcodes
 timezonefinder
 oauthlib~=3.2
+orjson

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,4 +7,3 @@ pyee>=8.0.0
 combo-lock~=0.2
 rich-click~=1.7
 rich~=13.7
-orjson


### PR DESCRIPTION
allow to run in more platforms, orjson fails to install in termux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added optional high-performance JSON serialization/deserialization with automatic fallback for full compatibility, including support for dataclass-like payloads.
* Performance
  * Faster conversion for media and stream entries when the optional fast JSON library is installed.
* Chores
  * Moved the fast JSON library to optional extras and removed it from core requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->