### PR TITLE
fix: handle issues in NVDA python stdlib

### DIFF
--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -122,7 +122,7 @@ class LOG:
                 handler.setFormatter(cls.formatter)
                 logger.addHandler(handler)
             except ImportError:
-                LOG.exception("Unable to import 'logging.handlers.RotatingFileHandler'. You seem to be running in a stripped down python version.")
+                logger.exception("Unable to import 'logging.handlers.RotatingFileHandler'. You seem to be running in a stripped down python version.")
 
         logger.setLevel(cls.level)
         cls._loggers[name] = logger

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 import sys
-from logging.handlers import RotatingFileHandler
 from os.path import join
 from pathlib import Path
 from typing import Optional, List, Set
@@ -110,13 +109,21 @@ class LOG:
             logger.addHandler(stdout_handler)
         # log to file
         if cls.base_path != "stdout":
-            os.makedirs(cls.base_path, exist_ok=True)
-            path = join(cls.base_path,
-                        cls.name.lower().strip() + ".log")
-            handler = RotatingFileHandler(path, maxBytes=cls.max_bytes,
-                                          backupCount=cls.backup_count)
-            handler.setFormatter(cls.formatter)
-            logger.addHandler(handler)
+            try:
+                # HACK: noticed in NVDA, the bundled python appears to be a
+                # stripped down version with missing stdlib components
+                # `logging.handlers` confirmed to be missing under that setup
+                from logging.handlers import RotatingFileHandler
+                os.makedirs(cls.base_path, exist_ok=True)
+                path = join(cls.base_path,
+                            cls.name.lower().strip() + ".log")
+                handler = RotatingFileHandler(path, maxBytes=cls.max_bytes,
+                                              backupCount=cls.backup_count)
+                handler.setFormatter(cls.formatter)
+                logger.addHandler(handler)
+            except ImportError:
+                LOG.exception("Unable to import 'logging.handlers.RotatingFileHandler'. You seem to be running in a stripped down python version.")
+
         logger.setLevel(cls.level)
         cls._loggers[name] = logger
         return logger


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes during logger setup when file-based logging support is unavailable; application continues with console/logging fallback.
  * Emits an error note instead of failing when file logging can't be enabled.

* **Refactor**
  * Logger initialization now enables file logging only when supported at runtime, improving resilience in restricted environments.
  * Reduces startup failures by making file logging optional and guarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->