### PR TITLE
fix: make the stopwatch test less strict

### DIFF
--- a/test/unittests/test_metrics.py
+++ b/test/unittests/test_metrics.py
@@ -11,22 +11,22 @@ class MetricsTests(unittest.TestCase):
         stopwatch = Stopwatch()
         with stopwatch:
             sleep(sleep_time)
-        self.assertEqual(round(stopwatch.time, 2), sleep_time)
+        self.assertLess(abs(stopwatch.time - sleep_time), 2)
 
     def test_stopwatch_reuse(self):
         sleep_time = 0.5
         stopwatch = Stopwatch()
         with stopwatch:
             sleep(sleep_time)
-        self.assertEqual(round(stopwatch.time, 2), sleep_time)
+        self.assertLess(abs(stopwatch.time - sleep_time), 0.01)
 
         with stopwatch:
             sleep(sleep_time)
-        self.assertEqual(round(stopwatch.time, 2), sleep_time)
+        self.assertLess(abs(stopwatch.time - sleep_time), 0.01) 
 
         with stopwatch:
             sleep(sleep_time)
-        self.assertEqual(round(stopwatch.time, 2), sleep_time)
+        self.assertLess(abs(stopwatch.time - sleep_time), 0.01) 
 
     def test_stopwatch_no_start(self):
         stopwatch = Stopwatch()


### PR DESCRIPTION
Right now it depends very much on the machine running the test being quick enough, and at least the Alpine CI builders don't seem to be quick enough. Making it less strict still confirms functionality but allows slower machines to also pass the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved timing test reliability by replacing strict exact-time assertions with tolerance-based checks for repeated stopwatch measurements. This reduces flaky failures caused by minor timing variations in test environments. No user-facing behavior or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->