### PR TITLE
feat: AsyncFakeBus alongside FakeBus

### DIFF
--- a/docs/fakebus.md
+++ b/docs/fakebus.md
@@ -52,6 +52,65 @@ bus.emit(FakeMessage("recognizer_loop:utterance", {"utterances": ["hello"]}))
 | `close()` | Calls `on_close()` |
 | `create_client()` | Returns `self` |
 
+For asyncio-native code, see [`AsyncFakeBus`](#asyncfakebus) below.
+
+---
+
+## `AsyncFakeBus`
+
+`AsyncFakeBus` — `ovos_utils/fakebus.py:351`
+
+In-process stand-in for `AsyncMessageBusClient` (from `ovos-bus-client`). Use this when your code is asyncio-native and needs a drop-in fake bus without a WebSocket connection. The API surface mirrors the real async client: coroutine methods keep you inside the event loop, while handler registration stays synchronous to match `pyee` and the real client's contract.
+
+```python
+import asyncio
+from ovos_utils.fakebus import AsyncFakeBus, FakeMessage
+
+async def main():
+    bus = AsyncFakeBus()
+
+    received = []
+
+    def on_ping(message):
+        received.append(message)
+
+    bus.on("test:ping", on_ping)
+
+    await bus.emit(FakeMessage("test:ping", {"n": 1}))
+    print(received)  # [FakeMessage("test:ping", ...)]
+
+    await bus.close()
+
+asyncio.run(main())
+```
+
+### Coroutine vs sync split
+
+| Sync (handler registration) | Async (I/O surface) |
+|---|---|
+| `on(msg_type, handler)` | `connect(*args, **kwargs)` |
+| `once(msg_type, handler)` | `close()` |
+| `remove(msg_type, handler)` | `emit(message)` |
+| `remove_all_listeners(event_name)` | `wait_for_message(message_type, timeout)` |
+| | `wait_for_response(message, reply_type, timeout)` |
+
+### Key Methods
+
+| Method | Description | Source |
+|---|---|---|
+| `connect()` | No-op; sets `connected_event` and `started_running = True` | `fakebus.py:409` |
+| `close()` | Clears `connected_event`, calls `on_close()` | `fakebus.py:418` |
+| `emit(message)` | Injects session, dispatches to `pyee` emitter | `fakebus.py:426` |
+| `wait_for_message(message_type, timeout)` | Awaits a single message of that type | `fakebus.py:489` |
+| `wait_for_response(message, reply_type, timeout)` | Emits a message and awaits the reply | `fakebus.py:513` |
+| `create_client()` | Returns `self` (backwards-compat shim) | `fakebus.py:543` |
+| `run_forever()` | Sets `started_running = True` (backwards-compat shim) | `fakebus.py:546` |
+| `run_in_thread()` | Calls `run_forever()` (backwards-compat shim) | `fakebus.py:549` |
+
+### Session Handling
+
+Session injection side effects are identical to `FakeBus`: `emit()` populates `message.context["session"]` from `SessionManager`, and `on_message()` feeds incoming messages back through `Session.from_message()` / `SessionManager.update()`. Both imports are lazy so the class works without `ovos-bus-client` installed.
+
 ---
 
 ## `FakeMessage`

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Shared utility library used by all OVOS components. Provides logging, process li
 |---|---|
 | `ovos_utils.log` | `LOG` — OVOS-wide logging class with optional file rotation |
 | `ovos_utils.process_utils` | `ProcessStatus`, `RuntimeRequirements`, `PIDLock`, `MonotonicEvent` |
-| `ovos_utils.fakebus` | `FakeBus`, `FakeMessage` — in-process bus for testing without a live WebSocket |
+| `ovos_utils.fakebus` | `FakeBus`, `AsyncFakeBus`, `FakeMessage` — in-process bus for testing without a live WebSocket |
 | `ovos_utils.events` | `EventContainer`, `EventSchedulerInterface`, handler wrappers |
 | `ovos_utils.file_utils` | Resource resolution, vocab loading, `FileWatcher` |
 | `ovos_utils.network_utils` | `get_ip()`, `is_connected_dns()`, `is_connected_http()`, `check_captive_portal()` |
@@ -60,6 +60,6 @@ pip install ovos-utils
 
 - [Logging](log.md) — `LOG`, `init_service_logger()`, `log_deprecation()`, `deprecated` decorator
 - [Process Utilities](process-utils.md) — `ProcessStatus`, `RuntimeRequirements`, `PIDLock`, `MonotonicEvent`
-- [FakeBus](fakebus.md) — `FakeBus`, `FakeMessage` — in-process message bus for testing
+- [FakeBus](fakebus.md) — `FakeBus`, `AsyncFakeBus`, `FakeMessage` — in-process message bus for testing
 - [Events](events.md) — `EventContainer`, `EventSchedulerInterface`, handler wrappers
 - [Utilities](utilities.md) — file, network, sound, threading, XDG helpers

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
+import warnings
 from copy import deepcopy
 from threading import Event
-import warnings
+
 from ovos_utils.log import LOG, log_deprecation
 from pyee import EventEmitter
 
@@ -344,3 +346,208 @@ class Message(FakeMessage):
         log_deprecation(
             "please import from ovos-bus-client directly! this import has been deprecated since version 0.1.0", "1.0.0")
         return FakeMessage(*args, **kwargs)
+
+
+class AsyncFakeBus:
+    """In-process stand-in for ``AsyncMessageBusClient``.
+
+    Mirrors the same surface as the real async bus client: ``connect`` /
+    ``close`` / ``emit`` / ``wait_for_message`` / ``wait_for_response`` are
+    coroutines; ``on`` / ``once`` / ``remove`` stay synchronous.
+
+    No WebSocket, no thread, no real I/O — every emit dispatches
+    synchronously through a ``pyee.EventEmitter`` to whatever handlers
+    are registered.
+
+    Useful both in tests (drop-in for ``AsyncMessageBusClient``) and at
+    runtime (anywhere a sync component expects the legacy ``FakeBus`` but
+    the surrounding code is asyncio-native).
+
+    The session-injection side effects match ``FakeBus`` so multi-turn
+    flows behave identically.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.started_running = False
+        self.session_id = "default"
+        self.ee = kwargs.get("emitter") or EventEmitter()
+        self.ee.on("error", self.on_error)
+        self.connected_event = asyncio.Event()
+        self.connected_event.set()
+        self.on_open()
+        try:
+            self.session_id = kwargs["session"].session_id
+        except Exception:
+            pass  # don't care
+
+        self.on("ovos.session.update_default",
+                self.on_default_session_update)
+
+    # ------------------------------------------------------------------
+    # Handler registration (sync — matches AsyncMessageBusClient)
+    # ------------------------------------------------------------------
+
+    def on(self, msg_type, handler):
+        self.ee.on(msg_type, handler)
+
+    def once(self, msg_type, handler):
+        self.ee.once(msg_type, handler)
+
+    def remove(self, msg_type, handler):
+        try:
+            self.ee.remove_listener(msg_type, handler)
+        except Exception:
+            pass
+
+    def remove_all_listeners(self, event_name):
+        self.ee.remove_all_listeners(event_name)
+
+    # ------------------------------------------------------------------
+    # Lifecycle (async)
+    # ------------------------------------------------------------------
+
+    async def connect(self, *args, **kwargs):
+        """No-op for the fake bus; matches the real client's lifecycle.
+
+        Returns immediately with ``connected_event`` set.
+        """
+        self.started_running = True
+        self.connected_event.set()
+        return self
+
+    async def close(self):
+        self.connected_event.clear()
+        self.on_close()
+
+    # ------------------------------------------------------------------
+    # emit (async) — same dispatch shape as FakeBus.emit
+    # ------------------------------------------------------------------
+
+    async def emit(self, message):
+        if "session" not in message.context:
+            try:  # replicate side effects
+                from ovos_bus_client.session import Session, SessionManager
+                sess = SessionManager.sessions.get(self.session_id) or \
+                       Session(self.session_id)
+                message.context["session"] = sess.serialize()
+            except ImportError:  # don't care
+                message.context["session"] = {"session_id": self.session_id}
+        self.ee.emit("message", message.serialize())
+        try:
+            self.ee.emit(message.msg_type, message)
+        except Exception as e:
+            LOG.exception(f"Error in event handler for '{message.msg_type}': {e}")
+        self.on_message(message.serialize())
+
+    # ------------------------------------------------------------------
+    # Sync helpers used internally — same as FakeBus
+    # ------------------------------------------------------------------
+
+    def on_message(self, *args):
+        """Handle an incoming websocket message.
+
+        @param args:
+            message (str): serialized Message
+        """
+        if len(args) == 1:
+            message = args[0]
+        else:
+            message = args[1]
+        parsed_message = FakeMessage.deserialize(message)
+        try:  # replicate side effects
+            from ovos_bus_client.session import Session, SessionManager
+            sess = Session.from_message(parsed_message)
+            if sess.session_id != "default":
+                # 'default' can only be updated by core
+                SessionManager.update(sess)
+        except ImportError:
+            pass  # don't care
+
+    def on_default_session_update(self, message):
+        try:  # replicate side effects
+            from ovos_bus_client.session import Session, SessionManager
+            new_session = message.data["session_data"]
+            sess = Session.deserialize(new_session)
+            SessionManager.update(sess, make_default=True)
+            LOG.debug("synced default_session")
+        except ImportError:
+            pass  # don't care
+
+    def on_error(self, error):
+        LOG.error(error)
+
+    def on_open(self):
+        pass
+
+    def on_close(self):
+        pass
+
+    # ------------------------------------------------------------------
+    # Waiters (async)
+    # ------------------------------------------------------------------
+
+    async def wait_for_message(self, message_type, timeout=3.0):
+        """Wait for a message of a specific type.
+
+        Arguments:
+            message_type (str): the message type of the expected message
+            timeout: seconds to wait before timeout, defaults to 3
+
+        Returns:
+            The received message or None if the response timed out
+        """
+        evt = asyncio.Event()
+        captured = {"msg": None}
+
+        def _rcv(m):
+            captured["msg"] = m
+            evt.set()
+
+        self.ee.once(message_type, _rcv)
+        try:
+            await asyncio.wait_for(evt.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+        return captured["msg"]
+
+    async def wait_for_response(self, message, reply_type=None, timeout=3.0):
+        """Send a message and wait for a response.
+
+        Arguments:
+            message (Message): message to send
+            reply_type (str): the message type of the expected reply.
+                              Defaults to "<message.msg_type>.response".
+            timeout: seconds to wait before timeout, defaults to 3
+
+        Returns:
+            The received message or None if the response timed out
+        """
+        reply_type = reply_type or message.msg_type + ".response"
+        evt = asyncio.Event()
+        captured = {"msg": None}
+
+        def _rcv(m):
+            captured["msg"] = m
+            evt.set()
+
+        self.ee.once(reply_type, _rcv)
+        await self.emit(message)
+        try:
+            await asyncio.wait_for(evt.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+        return captured["msg"]
+
+    # ------------------------------------------------------------------
+    # Backwards-compat passthroughs so AsyncFakeBus is a drop-in even for
+    # code paths that still call the threading-era helpers.
+    # ------------------------------------------------------------------
+
+    def create_client(self):
+        return self
+
+    def run_forever(self):
+        self.started_running = True
+
+    def run_in_thread(self):
+        self.run_forever()

--- a/test/unittests/test_async_fakebus.py
+++ b/test/unittests/test_async_fakebus.py
@@ -1,0 +1,202 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+"""Tests for AsyncFakeBus.
+
+Mirrors test_fakebus.py shape but exercises the async surface
+(connect / close / emit / wait_for_message / wait_for_response) plus
+the sync handler-registration contract that matches
+AsyncMessageBusClient.
+"""
+import asyncio
+import unittest
+
+from ovos_utils.fakebus import AsyncFakeBus, FakeMessage
+
+
+def _run(coro):
+    """Tiny helper so we can use plain unittest.TestCase."""
+    return asyncio.run(coro)
+
+
+class TestAsyncFakeBusLifecycle(unittest.TestCase):
+    def test_constructs_connected(self):
+        bus = AsyncFakeBus()
+        self.assertTrue(bus.connected_event.is_set())
+
+    def test_session_id_from_kwargs(self):
+        class _Sess:
+            session_id = "from-kwarg"
+        bus = AsyncFakeBus(session=_Sess())
+        self.assertEqual(bus.session_id, "from-kwarg")
+
+    def test_connect_is_noop_but_sets_event(self):
+        bus = AsyncFakeBus()
+        bus.connected_event.clear()
+        _run(bus.connect())
+        self.assertTrue(bus.connected_event.is_set())
+        self.assertTrue(bus.started_running)
+
+    def test_close_clears_connected_event(self):
+        bus = AsyncFakeBus()
+        self.assertTrue(bus.connected_event.is_set())
+        _run(bus.close())
+        self.assertFalse(bus.connected_event.is_set())
+
+
+class TestAsyncFakeBusHandlerRegistration(unittest.TestCase):
+    def test_on_then_emit_dispatches(self):
+        bus = AsyncFakeBus()
+        seen = []
+        bus.on("hello", lambda m: seen.append(m))
+        _run(bus.emit(FakeMessage("hello", {"x": 1})))
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0].msg_type, "hello")
+        self.assertEqual(seen[0].data["x"], 1)
+
+    def test_once_fires_only_once(self):
+        bus = AsyncFakeBus()
+        seen = []
+        bus.once("evt", lambda m: seen.append(m))
+        _run(bus.emit(FakeMessage("evt")))
+        _run(bus.emit(FakeMessage("evt")))
+        self.assertEqual(len(seen), 1)
+
+    def test_remove_handler(self):
+        bus = AsyncFakeBus()
+        seen = []
+
+        def cb(m):
+            seen.append(m)
+
+        bus.on("evt", cb)
+        bus.remove("evt", cb)
+        _run(bus.emit(FakeMessage("evt")))
+        self.assertEqual(seen, [])
+
+    def test_remove_all_listeners(self):
+        bus = AsyncFakeBus()
+        bus.on("evt", lambda m: None)
+        bus.on("evt", lambda m: None)
+        bus.remove_all_listeners("evt")
+        self.assertEqual(bus.ee.listeners("evt"), [])
+
+    def test_remove_unknown_handler_does_not_raise(self):
+        bus = AsyncFakeBus()
+        # not registered → silent
+        bus.remove("evt", lambda m: None)
+
+
+class TestAsyncFakeBusEmit(unittest.TestCase):
+    def test_emit_injects_session_context_when_missing(self):
+        bus = AsyncFakeBus()
+        msg = FakeMessage("hello", {})
+        self.assertNotIn("session", msg.context)
+        _run(bus.emit(msg))
+        self.assertIn("session", msg.context)
+
+    def test_emit_dispatches_raw_message_event(self):
+        bus = AsyncFakeBus()
+        raws = []
+        bus.on("message", lambda raw: raws.append(raw))
+        _run(bus.emit(FakeMessage("hello")))
+        self.assertEqual(len(raws), 1)
+        self.assertIn("hello", raws[0])
+
+
+class TestAsyncFakeBusWaitForMessage(unittest.TestCase):
+    def test_returns_matched_message_emitted_concurrently(self):
+        bus = AsyncFakeBus()
+
+        async def scenario():
+            async def feed():
+                await asyncio.sleep(0.02)
+                await bus.emit(FakeMessage("ping", {"flood_id": "x"}))
+            asyncio.create_task(feed())
+            got = await bus.wait_for_message("ping", timeout=1.0)
+            return got
+
+        got = _run(scenario())
+        self.assertIsNotNone(got)
+        self.assertEqual(got.msg_type, "ping")
+
+    def test_returns_none_on_timeout(self):
+        bus = AsyncFakeBus()
+
+        async def scenario():
+            return await bus.wait_for_message("never", timeout=0.05)
+
+        self.assertIsNone(_run(scenario()))
+
+
+class TestAsyncFakeBusWaitForResponse(unittest.TestCase):
+    def test_default_reply_type_is_msg_type_response(self):
+        bus = AsyncFakeBus()
+
+        async def scenario():
+            # echo the request as <type>.response when the request arrives
+            def echo(m):
+                # synchronous dispatch — fire the reply inline
+                # cannot await here; schedule on the loop instead
+                asyncio.create_task(
+                    bus.emit(FakeMessage(m.msg_type + ".response",
+                                         {"echoed": m.data})))
+            bus.on("ask", echo)
+            return await bus.wait_for_response(
+                FakeMessage("ask", {"q": 1}), timeout=1.0,
+            )
+
+        reply = _run(scenario())
+        self.assertIsNotNone(reply)
+        self.assertEqual(reply.msg_type, "ask.response")
+        self.assertEqual(reply.data["echoed"], {"q": 1})
+
+    def test_explicit_reply_type(self):
+        bus = AsyncFakeBus()
+
+        async def scenario():
+            def respond(m):
+                asyncio.create_task(bus.emit(FakeMessage("pong")))
+            bus.on("ping", respond)
+            return await bus.wait_for_response(
+                FakeMessage("ping"), reply_type="pong", timeout=1.0,
+            )
+
+        reply = _run(scenario())
+        self.assertIsNotNone(reply)
+        self.assertEqual(reply.msg_type, "pong")
+
+    def test_returns_none_on_timeout(self):
+        bus = AsyncFakeBus()
+
+        async def scenario():
+            return await bus.wait_for_response(
+                FakeMessage("never"), timeout=0.05,
+            )
+
+        self.assertIsNone(_run(scenario()))
+
+
+class TestAsyncFakeBusCompatShims(unittest.TestCase):
+    def test_create_client_returns_self(self):
+        bus = AsyncFakeBus()
+        self.assertIs(bus.create_client(), bus)
+
+    def test_run_forever_flips_started_running(self):
+        bus = AsyncFakeBus()
+        bus.started_running = False
+        bus.run_forever()
+        self.assertTrue(bus.started_running)
+
+    def test_run_in_thread_alias(self):
+        bus = AsyncFakeBus()
+        bus.started_running = False
+        bus.run_in_thread()
+        self.assertTrue(bus.started_running)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an asyncio-native sibling to `FakeBus` that mirrors the surface of `ovos_bus_client.client.AsyncMessageBusClient` (the `[async]` extra shipped in `ovos-bus-client` 2.0).

`FakeBus` has long been the standard test double for code that talks to the OVOS messagebus — but only for synchronous code. Now that an async client exists and downstream consumers (`ovos-busmon`, the upcoming chat-bridge migrations, future async pipeline plugins/skills) are starting to migrate, each one is reaching for its own ad-hoc stub.

`AsyncFakeBus` lives next to `FakeBus` in `ovos_utils.fakebus` for two reasons:

1. **Tests are often written without `ovos-bus-client` installed.** `ovos-utils` is the lightweight test-friendly dependency; keeping the fake here preserves that property.
2. **The fake is useful at runtime too**, not just in tests — mirroring how `FakeBus` is used today by `HiveMessageBusClient.connect(bus=FakeBus())` and embedded scenarios that don't need a real `ovos-core`.

## What's new

### `ovos_utils.fakebus.AsyncFakeBus`

| Method | Sync/Async | Notes |
|---|---|---|
| `connect()`, `close()` | async | No-op; flips `connected_event` |
| `emit(message)` | async | Same dispatch shape as `FakeBus.emit`, including session-context injection side effect |
| `wait_for_message(type, timeout)` | async | `asyncio.Event`-based |
| `wait_for_response(message, reply_type=None, timeout)` | async | Emit + wait; default `reply_type = msg_type + ".response"` |
| `on`/`once`/`remove`/`remove_all_listeners` | sync | Matches the real `AsyncMessageBusClient` handler-registration contract (pyee) |
| `on_message`, `on_default_session_update` | sync | Same `SessionManager` side effects as `FakeBus` |
| `create_client`, `run_forever`, `run_in_thread` | sync | Compat shims so `AsyncFakeBus` is a drop-in for `FakeBus`-style call sites |

Same lazy-import-from-`ovos_bus_client` pattern as `FakeBus` so the fake works in environments without `ovos-bus-client` installed.

## Tests

`test/unittests/test_async_fakebus.py` — 19 tests covering:

- Lifecycle (construction, `connect`/`close`, session_id-from-kwarg).
- Handler registration (`on`/`once`/`remove`/`remove_all_listeners` + dispatch).
- `emit` side effects (session injection, raw `"message"` event).
- `wait_for_message` (matched concurrently, timeout).
- `wait_for_response` (default `<type>.response`, explicit `reply_type`, timeout).
- Backwards-compat shims (`create_client`, `run_forever`, `run_in_thread`).

```
19 passed, 1 warning in 0.54s
```

All 23 existing `FakeBus` tests still pass; no changes to the sync class.

## Where this pays off concretely

The first call site is the `ovos-busmon` PR (https://github.com/TigreGotico/ovos-busmon/pull/5) where I had to hand-roll a `StubBus` for the smoke test. Replacing it with `AsyncFakeBus` removes ~10 lines of test scaffolding.

The next call sites:
- `HiveMind-deltachat-bridge` async migration — bridge tests need both an async OVOS-bus fake and an async HiveMind-bus fake.
- `hivemind-ovos-agent-plugin` async sidecar tests — multi-client client-isolation tests need a session-aware fake on the OVOS side.
- Any future async pipeline plugin or skill — the same place tests today reach for `FakeBus`.

## Test plan

- [x] 19 new tests + all 23 existing `FakeBus` tests pass.
- [ ] CI green across the Python matrix.
- [ ] First downstream use: update `ovos-busmon` smoke test to use `AsyncFakeBus` and confirm it works there.

Refs:
- OpenVoiceOS/ovos-bus-client PR #200 (`AsyncMessageBusClient`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `AsyncFakeBus`, an async-compatible in-process message bus client for testing
  * Supports async lifecycle management (connect, close) and messaging APIs (emit, wait_for_message, wait_for_response)
  * Synchronous handler registration methods (on, once, remove, remove_all_listeners) for compatibility
  * Comprehensive test suite validating async behavior and functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-utils/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->