### PR TITLE
feat: migrate ovos-utils onto ovos-spec-tools

### DIFF
--- a/ovos_utils/bracket_expansion.py
+++ b/ovos_utils/bracket_expansion.py
@@ -6,39 +6,21 @@ from ovos_utils.log import deprecated
 
 
 def expand_template(template: str) -> List[str]:
-    def expand_optional(text):
-        """Replace [optional] with two options: one with and one without."""
-        return re.sub(r"\[([^\[\]]+)\]", lambda m: f"({m.group(1)}|)", text)
+    """Expand a sentence template to its sample set.
 
-    def expand_alternatives(text):
-        """Expand (alternative|choices) into a list of choices."""
-        parts = []
-        for segment in re.split(r"(\([^\(\)]+\))", text):
-            if segment.startswith("(") and segment.endswith(")"):
-                options = segment[1:-1].split("|")
-                parts.append(options)
-            else:
-                parts.append([segment])
-        return itertools.product(*parts)
+    Resolves ``(a|b)`` alternatives and ``[optional]`` segments; named
+    ``{slot}`` placeholders are carried through unchanged. The samples are
+    returned sorted.
 
-    def fully_expand(texts):
-        """Iteratively expand alternatives until all possibilities are covered."""
-        result = set(texts)
-        while True:
-            expanded = set()
-            for text in result:
-                options = list(expand_alternatives(text))
-                expanded.update(["".join(option).strip() for option in options])
-            if expanded == result:  # No new expansions found
-                break
-            result = expanded
-        return sorted(result)  # Return a sorted list for consistency
-
-    # Expand optional items first
-    template = expand_optional(template)
-
-    # Fully expand all combinations of alternatives
-    return fully_expand([template])
+    Delegates to the OVOS-INTENT-1 reference expander,
+    :func:`ovos_spec_tools.expand` — the single conformant implementation;
+    new code should import ``expand`` from ``ovos_spec_tools`` directly. A
+    template the specification rejects as malformed (a single-branch group,
+    an empty sample, a slot-only template, …) raises
+    :class:`ovos_spec_tools.MalformedTemplate`.
+    """
+    from ovos_spec_tools import expand as _spec_expand
+    return sorted(_spec_expand(template))
 
 
 def expand_slots(template: str, slots: Dict[str, List[str]]) -> List[str]:

--- a/ovos_utils/bracket_expansion.py
+++ b/ovos_utils/bracket_expansion.py
@@ -2,9 +2,15 @@ import itertools
 import re
 from typing import List, Dict
 import warnings
+
+from ovos_spec_tools import expand as _spec_expand
+
 from ovos_utils.log import deprecated
+from ovos_utils.version import VERSION_MAJOR
 
 
+@deprecated("import 'expand' from 'ovos_spec_tools' instead",
+            f"{VERSION_MAJOR + 1}.0.0")
 def expand_template(template: str) -> List[str]:
     """Expand a sentence template to its sample set.
 
@@ -12,14 +18,17 @@ def expand_template(template: str) -> List[str]:
     ``{slot}`` placeholders are carried through unchanged. The samples are
     returned sorted.
 
-    Delegates to the OVOS-INTENT-1 reference expander,
-    :func:`ovos_spec_tools.expand` — the single conformant implementation;
-    new code should import ``expand`` from ``ovos_spec_tools`` directly. A
-    template the specification rejects as malformed (a single-branch group,
-    an empty sample, a slot-only template, …) raises
-    :class:`ovos_spec_tools.MalformedTemplate`.
+    .. deprecated::
+        Import :func:`expand` from ``ovos_spec_tools`` directly — it is the
+        single conformant OVOS-INTENT-1 expander, and what this now delegates
+        to. A template the specification rejects as malformed (a single-branch
+        group, an empty sample, a slot-only template, …) raises
+        :class:`ovos_spec_tools.MalformedTemplate`.
     """
-    from ovos_spec_tools import expand as _spec_expand
+    # stacklevel=3: warn() -> expand_template body -> @deprecated wrapper -> caller
+    warnings.warn("expand_template is deprecated; import 'expand' from "
+                  "'ovos_spec_tools' instead",
+                  DeprecationWarning, stacklevel=3)
     return sorted(_spec_expand(template))
 
 
@@ -35,7 +44,7 @@ def expand_slots(template: str, slots: Dict[str, List[str]]) -> List[str]:
         list[str]: A list of all expanded combinations.
     """
     # Expand alternatives and optional components
-    base_expansions = expand_template(template)
+    base_expansions = sorted(_spec_expand(template))
 
     # Process slots
     all_sentences = []

--- a/ovos_utils/dialog.py
+++ b/ovos_utils/dialog.py
@@ -1,20 +1,31 @@
 import os
 import random
 import re
+import warnings
 from os.path import join
 from pathlib import Path
 from typing import Optional
 
-from ovos_utils.bracket_expansion import expand_template
+from ovos_spec_tools import expand
+
 from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.lang import translate_word
-from ovos_utils.log import LOG, log_deprecation
+from ovos_utils.log import LOG, deprecated, log_deprecation
+from ovos_utils.version import VERSION_MAJOR
 
 
 class MustacheDialogRenderer:
     """A dialog template renderer based on the mustache templating language."""
 
+    @deprecated("use the OVOS-INTENT-2 §4.2 dialog renderer in "
+                "'ovos_spec_tools' ('render' / 'DialogRenderer')",
+                f"{VERSION_MAJOR + 1}.0.0")
     def __init__(self):
+        warnings.warn(
+            "MustacheDialogRenderer is deprecated; use the OVOS-INTENT-2 §4.2 "
+            "dialog renderer in 'ovos_spec_tools' ('render' / "
+            "'DialogRenderer')",
+            DeprecationWarning, stacklevel=3)
         self.templates = {}
         self.recent_phrases = []
 
@@ -92,7 +103,7 @@ class MustacheDialogRenderer:
             line = template_functions[index % len(template_functions)]
         # Replace {key} in line with matching values from context
         line = line.format(**context)
-        line = random.choice(expand_template(line))
+        line = random.choice(sorted(expand(line)))
 
         # Here's where we keep track of what we've said recently. Remember,
         # this is by line in the .dialog file, not by exact phrase
@@ -104,6 +115,8 @@ class MustacheDialogRenderer:
         return line
 
 
+@deprecated("use 'ovos_spec_tools.LocaleResources' to load .dialog resources",
+            f"{VERSION_MAJOR + 1}.0.0")
 def load_dialogs(dialog_dir: str,
                  renderer: Optional[MustacheDialogRenderer] = None) -> \
         MustacheDialogRenderer:
@@ -116,6 +129,10 @@ def load_dialogs(dialog_dir: str,
     Returns:
         a loaded instance of a dialog renderer
     """
+    warnings.warn(
+        "load_dialogs is deprecated; use 'ovos_spec_tools.LocaleResources' "
+        "to load .dialog resources",
+        DeprecationWarning, stacklevel=3)
     if renderer is None:
         renderer = MustacheDialogRenderer()
 
@@ -132,6 +149,8 @@ def load_dialogs(dialog_dir: str,
     return renderer
 
 
+@deprecated("use the OVOS-INTENT-2 §4.2 dialog renderer in 'ovos_spec_tools' "
+            "('render' / 'DialogRenderer')", f"{VERSION_MAJOR + 1}.0.0")
 def get_dialog(phrase: str, lang: str = None,
                context: Optional[dict] = None) -> str:
     """
@@ -149,6 +168,10 @@ def get_dialog(phrase: str, lang: str = None,
         str: a randomized and/or translated version of the phrase
     """
 
+    warnings.warn(
+        "get_dialog is deprecated; use the OVOS-INTENT-2 §4.2 dialog renderer "
+        "in 'ovos_spec_tools' ('render' / 'DialogRenderer')",
+        DeprecationWarning, stacklevel=3)
     if not lang:
         log_deprecation("Expected a string lang and got None.", "0.1.0")
         try:

--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -9,7 +9,7 @@ from sys import platform
 from threading import RLock
 from typing import Optional, List
 
-from ovos_utils.bracket_expansion import expand_template
+from ovos_spec_tools import expand
 from ovos_utils.log import LOG, log_deprecation
 
 
@@ -238,7 +238,7 @@ def read_vocab_file(path: str) -> List[List[str]]:
         for line in voc_file.readlines():
             if line.startswith('#') or line.strip() == '':
                 continue
-            vocab.append(expand_template(line.lower()))
+            vocab.append(sorted(expand(line.lower())))
     return vocab
 
 

--- a/ovos_utils/geolocation.py
+++ b/ovos_utils/geolocation.py
@@ -3,8 +3,9 @@ from typing import Dict, Any, Optional
 import requests
 from requests.exceptions import RequestException, Timeout
 
+from ovos_spec_tools import standardize_lang
+
 from ovos_utils import timed_lru_cache
-from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_utils.network_utils import get_external_ip, is_valid_ip
 
@@ -234,7 +235,7 @@ def get_ip_geolocation(ip: Optional[str] = None,
         raise ValueError(f"Invalid IP address: {ip}")
 
     # normalize language to expected values by ip-api.com
-    lang = standardize_lang_tag(lang).split("-")[0]
+    lang = standardize_lang(lang).split("-")[0]
     if lang not in ["en", "de", "es", "pt", "fr", "ja", "zh", "ru"]:
         LOG.warning(f"Language unsupported by ip-api.com ({lang}), defaulting to english")
         lang = "en"

--- a/ovos_utils/lang/__init__.py
+++ b/ovos_utils/lang/__init__.py
@@ -13,18 +13,20 @@ from ovos_utils.version import VERSION_MAJOR
 def standardize_lang_tag(lang_code: str, macro=True) -> str:
     """Normalize a BCP-47 language tag.
 
+    With ``macro=True`` the region is dropped, returning the bare primary
+    language subtag (``en-US`` -> ``en``).
+
     .. deprecated::
         Use :func:`ovos_spec_tools.standardize_lang` — the conformant OVOS
-        language-tag normalizer, and what this now delegates to. The ``macro``
-        parameter is accepted for backward compatibility but no longer affects
-        the result.
+        language-tag normalizer, and what this now delegates to.
     """
     # stacklevel=3: warn() -> this body -> @deprecated wrapper -> caller
     warnings.warn("standardize_lang_tag is deprecated; use 'standardize_lang' "
                   "from 'ovos_spec_tools' instead",
                   DeprecationWarning, stacklevel=3)
     from ovos_spec_tools import standardize_lang
-    return standardize_lang(lang_code)
+    tag = standardize_lang(lang_code)
+    return tag.split("-")[0] if macro else tag
 
 
 @deprecated("use 'closest_lang' from 'ovos_spec_tools' "

--- a/ovos_utils/lang/__init__.py
+++ b/ovos_utils/lang/__init__.py
@@ -8,18 +8,23 @@ from ovos_utils.log import deprecated
 from ovos_utils.version import VERSION_MAJOR
 
 
+@deprecated("use 'standardize_lang' from 'ovos_spec_tools' instead",
+            f"{VERSION_MAJOR + 1}.0.0")
 def standardize_lang_tag(lang_code: str, macro=True) -> str:
-    """https://langcodes-hickford.readthedocs.io/en/sphinx/index.html"""
-    try:
-        from langcodes import standardize_tag as std
-        return str(std(lang_code, macro=macro))
-    except Exception:
-        if macro:
-            return lang_code.split("-")[0].lower()
-        if "-" in lang_code:
-            a, b = lang_code.split("-", 1)
-            return f"{a.lower()}-{b.upper()}"
-        return lang_code.lower()
+    """Normalize a BCP-47 language tag.
+
+    .. deprecated::
+        Use :func:`ovos_spec_tools.standardize_lang` — the conformant OVOS
+        language-tag normalizer, and what this now delegates to. The ``macro``
+        parameter is accepted for backward compatibility but no longer affects
+        the result.
+    """
+    # stacklevel=3: warn() -> this body -> @deprecated wrapper -> caller
+    warnings.warn("standardize_lang_tag is deprecated; use 'standardize_lang' "
+                  "from 'ovos_spec_tools' instead",
+                  DeprecationWarning, stacklevel=3)
+    from ovos_spec_tools import standardize_lang
+    return standardize_lang(lang_code)
 
 
 @deprecated("use 'closest_lang' from 'ovos_spec_tools' "

--- a/ovos_utils/lang/__init__.py
+++ b/ovos_utils/lang/__init__.py
@@ -1,8 +1,11 @@
+import warnings
 from os import listdir
 from os.path import isdir, join
 from typing import Optional
 
 from ovos_utils.file_utils import resolve_resource_file
+from ovos_utils.log import deprecated
+from ovos_utils.version import VERSION_MAJOR
 
 
 def standardize_lang_tag(lang_code: str, macro=True) -> str:
@@ -19,29 +22,30 @@ def standardize_lang_tag(lang_code: str, macro=True) -> str:
         return lang_code.lower()
 
 
-def get_language_dir(base_path: str, lang: str ="en-US") -> Optional[str]:
-    """ checks for all language variations and returns best path """
-    lang = standardize_lang_tag(lang)
+@deprecated("use 'closest_lang' from 'ovos_spec_tools' "
+            "(or 'ovos_spec_tools.LocaleResources')",
+            f"{VERSION_MAJOR + 1}.0.0")
+def get_language_dir(base_path: str, lang: str = "en-US") -> Optional[str]:
+    """Return the best-matching ``<lang>/`` directory under ``base_path``.
 
-    candidates = []
-    for f in listdir(base_path):
-        if isdir(f"{base_path}/{f}"):
-            try:
-                from langcodes import tag_distance
-                score = tag_distance(lang, f)
-            except Exception:  # not a valid language code
-                continue
-                # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-                # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-                # 1- 3 -> These codes indicate a minor regional difference.
-                # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
-            if score < 10:
-                candidates.append((f"{base_path}/{f}", score))
-    if not candidates:
+    .. deprecated::
+        Use :func:`ovos_spec_tools.closest_lang` to resolve a language tag
+        against the available ones, or :class:`ovos_spec_tools.LocaleResources`
+        which resolves locale directories itself.
+    """
+    # stacklevel=3: warn() -> this body -> @deprecated wrapper -> caller
+    warnings.warn("get_language_dir is deprecated; use 'closest_lang' from "
+                  "'ovos_spec_tools' (or 'ovos_spec_tools.LocaleResources')",
+                  DeprecationWarning, stacklevel=3)
+    from ovos_spec_tools import closest_lang
+    try:
+        names = [f for f in listdir(base_path) if isdir(join(base_path, f))]
+    except (FileNotFoundError, NotADirectoryError):
         return None
-    # sort by distance to target lang code
-    candidates = sorted(candidates, key=lambda k: k[1])
-    return candidates[0][0]
+    # closest_lang accepts a tag distance below 10 — the same threshold this
+    # used previously (OVOS-INTENT-2 §2.2).
+    match = closest_lang(lang, names)
+    return join(base_path, match) if match is not None else None
 
 
 def translate_word(name, lang='en-US'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
+    "ovos-spec-tools>=0.0.1a2",
 ]
 
 [project.urls]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,3 +7,4 @@ pyee>=8.0.0
 combo-lock~=0.2
 rich-click~=1.7
 rich~=13.7
+ovos-spec-tools>=0.0.1a2

--- a/test/unittests/test_bracket_expansion.py
+++ b/test/unittests/test_bracket_expansion.py
@@ -35,20 +35,15 @@ class TestTemplateExpansion(unittest.TestCase):
                               'change the brightness to high and color to blue']
         self.assertEqual(expanded_sentences, expected_sentences)
 
+    def test_malformed_template_raises(self):
+        # a template whose expansion would yield an empty string is malformed
+        # (OVOS-INTENT-1 §3.6) — it raises rather than producing ''
+        from ovos_spec_tools import MalformedTemplate
+        with self.assertRaises(MalformedTemplate):
+            expand_template("[(this|that) is optional]")
+
     def test_expand_template(self):
         # Test for template expansion
-        templates = [
-            "[hello,] (call me|my name is) {name}",
-            "Expand (alternative|choices) into a list of choices.",
-            "sentences have [optional] words ",
-            "alternative words can be (used|written)",
-            "sentence[s] can have (pre|suf)fixes mid word too",
-            "do( the | )thing(s|) (old|with) style and( no | )spaces",
-            "[(this|that) is optional]",
-            "tell me a [{joke_type}] joke",
-            "play {query} [in ({device_name}|{skill_name}|{zone_name})]"
-        ]
-
         expected_outputs = {
             "[hello,] (call me|my name is) {name}": [
                 "call me {name}",
@@ -60,9 +55,11 @@ class TestTemplateExpansion(unittest.TestCase):
                 "Expand alternative into a list of choices.",
                 "Expand choices into a list of choices."
             ],
+            # an emptied [optional] no longer leaves a double space —
+            # OVOS-INTENT-1 §4.1 normalizes whitespace to single spaces
             "sentences have [optional] words ": [
-                "sentences have  words",
-                "sentences have optional words"
+                "sentences have optional words",
+                "sentences have words"
             ],
             "alternative words can be (used|written)": [
                 "alternative words can be used",
@@ -92,12 +89,8 @@ class TestTemplateExpansion(unittest.TestCase):
                 "do things with style and no spaces",
                 "do things with style and spaces"
             ],
-            "[(this|that) is optional]": [
-                '',
-                'that is optional',
-                'this is optional'],
             "tell me a [{joke_type}] joke": [
-                "tell me a  joke",
+                "tell me a joke",
                 "tell me a {joke_type} joke"
             ],
             "play {query} [in ({device_name}|{skill_name}|{zone_name})]": [

--- a/test/unittests/test_lang.py
+++ b/test/unittests/test_lang.py
@@ -24,15 +24,12 @@ from unittest.mock import patch
 class TestStandardizeLangTag(unittest.TestCase):
     """Tests for standardize_lang_tag."""
 
-    def test_macro_no_longer_strips_region(self) -> None:
-        """`macro` is kept for backward compatibility but no longer changes the
-        result — standardize_lang_tag delegates to ovos_spec_tools.standardize_lang,
-        which keeps the region (the old macro region-stripping was inconsistent
-        with the langcodes path and is treated as a bug)."""
+    def test_macro_strips_region(self) -> None:
+        """standardize_lang_tag(macro=True) should return the bare language."""
         from ovos_utils.lang import standardize_lang_tag
         with patch.dict("sys.modules", {"langcodes": None}):
             result = standardize_lang_tag("en-US", macro=True)
-        self.assertEqual(result, "en-US")
+        self.assertEqual(result, "en")
 
     def test_non_macro_preserves_region(self) -> None:
         """standardize_lang_tag(macro=False) should keep the region part."""

--- a/test/unittests/test_lang.py
+++ b/test/unittests/test_lang.py
@@ -24,13 +24,15 @@ from unittest.mock import patch
 class TestStandardizeLangTag(unittest.TestCase):
     """Tests for standardize_lang_tag."""
 
-    def test_macro_strips_region(self) -> None:
-        """standardize_lang_tag(macro=True) should return bare language code."""
+    def test_macro_no_longer_strips_region(self) -> None:
+        """`macro` is kept for backward compatibility but no longer changes the
+        result — standardize_lang_tag delegates to ovos_spec_tools.standardize_lang,
+        which keeps the region (the old macro region-stripping was inconsistent
+        with the langcodes path and is treated as a bug)."""
         from ovos_utils.lang import standardize_lang_tag
-        # When langcodes not available, falls back to split on '-'
         with patch.dict("sys.modules", {"langcodes": None}):
             result = standardize_lang_tag("en-US", macro=True)
-        self.assertEqual(result, "en")
+        self.assertEqual(result, "en-US")
 
     def test_non_macro_preserves_region(self) -> None:
         """standardize_lang_tag(macro=False) should keep the region part."""


### PR DESCRIPTION
Part of the OVOS-wide migration onto **ovos-spec-tools** (OpenVoiceOS/architecture#7),
the conformant reference implementation of the OVOS specifications.

This migrates `ovos-utils` — template expansion, language matching and dialog —
onto `ovos-spec-tools`, and adds it as a dependency. The same machinery is
reimplemented across ~7 (expansion) / ~12 (language) repos; `ovos-utils` holds
the de-facto shared copies.

## Changes

- **Template expansion** — `bracket_expansion.expand_template()` delegates to
  `ovos_spec_tools.expand`; `expand_slots`, `dialog.py` and `file_utils.py`
  call it directly.
- **Language matching** — `lang.get_language_dir()` delegates to
  `ovos_spec_tools.closest_lang`; `lang.standardize_lang_tag()` delegates to
  `ovos_spec_tools.standardize_lang` (with `macro=True` it then strips the
  region with `.split("-")[0]`, as before). `geolocation.py` uses
  `standardize_lang` directly.
- **Dialog** — `MustacheDialogRenderer` renders via `ovos_spec_tools.expand`.

## Deprecations

`expand_template`, `get_language_dir`, `standardize_lang_tag`,
`MustacheDialogRenderer`, `load_dialogs` and `get_dialog` are deprecated toward
`ovos-spec-tools`. Each **both** emits a `DeprecationWarning` (visible to IDEs
and tooling) **and** logs via the `@deprecated` helper. The removal version is
the next major release, derived from `version.py` (`VERSION_MAJOR + 1`).

## Behaviour change — conformance with OVOS-INTENT-1

Stricter, deliberately — the old behaviour was a bug:

- a **malformed** template (a single-branch group, an empty sample, a
  slot-only template) now raises `MalformedTemplate` instead of silently
  producing a degenerate result;
- whitespace within a sample is **normalized to single spaces**.

`test_bracket_expansion.py` is updated to the conformant output, with a test
added for the malformed-template raise.

## Verification

The full `test/unittests/` suite passes (909 passed) except one unrelated
pre-existing failure (`test_messagebus::test_import_emits_deprecation_warning`),
which is present on `dev` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)