### PR TITLE
fix: standardize_lang_tag macro=True preserves region (restore langcodes semantics)

### DIFF
--- a/ovos_utils/lang/__init__.py
+++ b/ovos_utils/lang/__init__.py
@@ -13,20 +13,33 @@ from ovos_utils.version import VERSION_MAJOR
 def standardize_lang_tag(lang_code: str, macro=True) -> str:
     """Normalize a BCP-47 language tag.
 
-    With ``macro=True`` the region is dropped, returning the bare primary
-    language subtag (``en-US`` -> ``en``).
+    ``macro`` controls **macrolanguage substitution** per
+    :func:`langcodes.standardize_tag` — it swaps a sublanguage for its
+    macrolanguage (``cmn`` -> ``zh``, ``nb`` -> ``no``). It does **not**
+    strip the region: ``"en-US"`` round-trips through both ``macro=True``
+    and ``macro=False`` unchanged.
 
     .. deprecated::
         Use :func:`ovos_spec_tools.standardize_lang` — the conformant OVOS
-        language-tag normalizer, and what this now delegates to.
+        language-tag normalizer. ``standardize_lang`` always returns the
+        region-preserving form (it does not take a ``macro`` argument);
+        if you need macrolanguage substitution, call
+        :func:`langcodes.standardize_tag` directly.
     """
     # stacklevel=3: warn() -> this body -> @deprecated wrapper -> caller
     warnings.warn("standardize_lang_tag is deprecated; use 'standardize_lang' "
                   "from 'ovos_spec_tools' instead",
                   DeprecationWarning, stacklevel=3)
-    from ovos_spec_tools import standardize_lang
-    tag = standardize_lang(lang_code)
-    return tag.split("-")[0] if macro else tag
+    try:
+        from langcodes import standardize_tag
+        return str(standardize_tag(lang_code, macro=macro))
+    except ImportError:
+        # langcodes is optional. Without it, fall back to the spec-tools
+        # normalizer (region-preserving). The ``macro`` argument is a
+        # no-op in this branch because macrolanguage tables live in
+        # langcodes itself.
+        from ovos_spec_tools import standardize_lang
+        return standardize_lang(lang_code)
 
 
 @deprecated("use 'closest_lang' from 'ovos_spec_tools' "

--- a/test/unittests/test_lang.py
+++ b/test/unittests/test_lang.py
@@ -24,37 +24,41 @@ from unittest.mock import patch
 class TestStandardizeLangTag(unittest.TestCase):
     """Tests for standardize_lang_tag."""
 
-    def test_macro_strips_region(self) -> None:
-        """standardize_lang_tag(macro=True) should return the bare language."""
+    def test_macro_preserves_region(self) -> None:
+        """standardize_lang_tag(macro=True) preserves the region.
+
+        ``macro`` is a langcodes concept — it controls *macrolanguage*
+        substitution (``cmn`` -> ``zh``, ``nb`` -> ``no``), not region
+        stripping. ``en-US`` round-trips unchanged."""
         from ovos_utils.lang import standardize_lang_tag
-        with patch.dict("sys.modules", {"langcodes": None}):
-            result = standardize_lang_tag("en-US", macro=True)
-        self.assertEqual(result, "en")
+        self.assertEqual(standardize_lang_tag("en-US", macro=True), "en-US")
+        self.assertEqual(standardize_lang_tag("en-us", macro=True), "en-US")
 
     def test_non_macro_preserves_region(self) -> None:
-        """standardize_lang_tag(macro=False) should keep the region part."""
+        """standardize_lang_tag(macro=False) preserves the region too —
+        the difference between macro=True/False is macrolanguage
+        substitution, not region handling."""
+        from ovos_utils.lang import standardize_lang_tag
+        self.assertEqual(standardize_lang_tag("en-us", macro=False), "en-US")
+
+    def test_macro_substitutes_macrolanguage(self) -> None:
+        """With ``macro=True``, langcodes maps a sublanguage onto its
+        macrolanguage. ``cmn`` (Mandarin) -> ``zh`` (Chinese);
+        ``macro=False`` keeps the original tag."""
+        from ovos_utils.lang import standardize_lang_tag
+        self.assertEqual(standardize_lang_tag("cmn", macro=True), "zh")
+        self.assertEqual(standardize_lang_tag("cmn", macro=False), "cmn")
+
+    def test_fallback_without_langcodes(self) -> None:
+        """With langcodes unavailable, ``standardize_lang_tag`` falls
+        back to spec-tools (also region-preserving). ``macro`` is a
+        no-op in this branch."""
         from ovos_utils.lang import standardize_lang_tag
         with patch.dict("sys.modules", {"langcodes": None}):
-            result = standardize_lang_tag("en-us", macro=False)
-        self.assertEqual(result, "en-US")
-
-    def test_no_region_tag(self) -> None:
-        """standardize_lang_tag with no '-' should return lowercased tag."""
-        from ovos_utils.lang import standardize_lang_tag
-        with patch.dict("sys.modules", {"langcodes": None}):
-            result = standardize_lang_tag("EN", macro=False)
-        self.assertEqual(result, "en")
-
-    def test_with_langcodes_library(self) -> None:
-        """standardize_lang_tag should call langcodes.standardize_tag when available."""
-        mock_langcodes = unittest.mock.MagicMock()
-        mock_langcodes.standardize_tag.return_value = "en"
-
-        with patch.dict("sys.modules", {"langcodes": mock_langcodes}):
-            from ovos_utils.lang import standardize_lang_tag
-            result = standardize_lang_tag("en-US", macro=True)
-        # Result is whatever langcodes returns
-        self.assertIsInstance(result, str)
+            self.assertEqual(
+                standardize_lang_tag("en-us", macro=True), "en-US")
+            self.assertEqual(
+                standardize_lang_tag("EN", macro=False), "en")
 
 
 class TestGetLanguageDir(unittest.TestCase):


### PR DESCRIPTION
The spec-tools migration of `standardize_lang_tag` changed the `macro` argument from its historic meaning to a different operation. Restore the original semantics.

## What broke

**Historic body** (pre-migration, commit `9baa615`):

```python
from langcodes import standardize_tag as std
return str(std(lang_code, macro=macro))
```

`langcodes.standardize_tag(..., macro=True)` performs **macrolanguage substitution** — it swaps a sublanguage for its macrolanguage (`cmn` -> `zh`, `nb` -> `no`). It does **not** strip the region. `en-US` round-trips unchanged.

**Current body** (post-migration, commit `19f6fba`):

```python
tag = standardize_lang(lang_code)             # spec-tools — preserves region
return tag.split('-')[0] if macro else tag   # strips region
```

This conflates *macro* with *primary subtag only*. `en-US` -> `en`. Every caller passing the default `macro=True` (`ovos_bus_client.session:316`, transformer plugins, …) now gets region-stripped output.

Observed downstream symptoms:

- `ovos_bus_client.SessionManager` silently rewrites `session.lang` from `en-US` to `en` on every message.
- ovoscope's `test_final_session` equality fails because the inbound `Session(lang='en-US')` round-trips back as `lang='en'`.
- Locale resource lookups that key on the region (e.g. `closest_lang('en', [...])`) sometimes fail to resolve when they should.
- ovos-core PR #763 had to ship a local `get_message_lang` workaround for this.
- ovos-utterance-plugin-cancel PR #32 had to drop `final_session` from its ovoscope cases to work around it.

## Fix

Delegate `macro` back to `langcodes.standardize_tag` as it did pre-migration. When langcodes is unavailable, fall back to spec-tools' `standardize_lang` (also region-preserving) and treat `macro` as a no-op (macrolanguage tables live in langcodes itself).

## Tests

Updated `test/unittests/test_lang.py` to pin the corrected behaviour:

- `macro=True` **preserves** the region (`en-US` -> `en-US`).
- `macro=True` **substitutes** macrolanguages (`cmn` -> `zh`).
- `macro=False` preserves both region and sublanguage.
- Fallback without langcodes still region-preserves.

11/11 tests in `test_lang.py` pass; full suite green except an unrelated `deltachat` plugin import quirk.

## Downstream unblocked

This fix lets us drop:
- The local `get_message_lang` workaround in ovos-core PR #763.
- The `final_session` skip in ovos-utterance-plugin-cancel PR #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)