### PR TITLE
fix: allow json-database 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.9"
 dependencies = [
     "pexpect~=4.9",
     "requests~=2.26",
-    "json_database~=0.10",
+    "json_database>=0.10,<2.0.0",
     "kthread~=0.2",
     "watchdog",
     "pyee>=8.0.0",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 pexpect~=4.9
 requests~=2.26
-json_database~=0.10
+json_database>=0.10,<2.0.0
 kthread~=0.2
 watchdog
 pyee>=8.0.0


### PR DESCRIPTION
`json_database~=0.10` resolves to `>=0.10,<1.0`, excluding json_database 1.x (now published as `1.0.2a1`, which dropped the duplicate `hivemind-json-db-plugin` entry point). Since **ovos-utils is foundational** (everything depends on it), this cap is one of the last blockers preventing json_database 1.x from resolving in the ovos-releases alpha set. Widen to `>=0.10,<2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)