### PR TITLE
feat: FakeBus mirrors the legacy<->ovos.* namespace migration

### DIFF
--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -3,6 +3,7 @@ import warnings
 from threading import Event
 
 from ovos_utils.log import LOG, log_deprecation
+from ovos_spec_tools import NamespaceTranslator
 from pyee import EventEmitter
 
 
@@ -21,6 +22,14 @@ class FakeBus:
         self.session_id = "default"
         self.ee = kwargs.get("emitter") or EventEmitter()
         self.ee.on("error", self.on_error)
+        # mirror MessageBusClient's namespace migration so the test/satellite
+        # double bridges legacy<->ovos.* topics identically. Both default on;
+        # override per-instance with modernize=/emit_legacy= kwargs.
+        self._translator = NamespaceTranslator(
+            modernize=kwargs.get("modernize", True),
+            emit_legacy=kwargs.get("emit_legacy", True))
+        self._handler_guards = {}        # handler -> shared mirror-guard
+        self._dedup_registrations = {}   # handler -> [(msg_type, wrapped), ...]
         self.on_open()
         try:
             self.session_id = kwargs["session"].session_id
@@ -31,6 +40,22 @@ class FakeBus:
                 self.on_default_session_update)
 
     def on(self, msg_type, handler):
+        # wrap handlers on migrated topics so a handler subscribed to both the
+        # legacy and ovos.* topic fires once (the mirror is dropped)
+        if self._translator.is_migrated(msg_type):
+            guard = self._handler_guards.get(handler)
+            if guard is None:
+                guard = self._translator.new_mirror_guard()
+                self._handler_guards[handler] = guard
+
+            def wrapped(message=None):
+                if guard(message):
+                    return
+                return handler(message)
+
+            self.ee.on(msg_type, wrapped)
+            self._dedup_registrations.setdefault(handler, []).append((msg_type, wrapped))
+            return
         self.ee.on(msg_type, handler)
 
     def once(self, msg_type, handler):
@@ -50,6 +75,13 @@ class FakeBus:
             self.ee.emit(message.msg_type, message)
         except Exception as e:
             LOG.exception(f"Error in event handler for '{message.msg_type}': {e}")
+        # namespace migration: also dispatch the counterpart topic(s) so a
+        # listener on either namespace receives the event (consumers dedupe)
+        for topic in self._translator.counterpart_topics(message.msg_type):
+            try:
+                self.ee.emit(topic, message.forward(topic, message.data))
+            except Exception as e:
+                LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
         self.on_message(message.serialize())
 
     def on_message(self, *args):
@@ -135,6 +167,18 @@ class FakeBus:
         return msg
 
     def remove(self, msg_type, handler):
+        regs = self._dedup_registrations.get(handler)
+        if regs:
+            for ev, wrapped in [r for r in regs if r[0] == msg_type]:
+                try:
+                    self.ee.remove_listener(ev, wrapped)
+                except Exception:
+                    pass
+                regs.remove((ev, wrapped))
+            if not regs:
+                self._dedup_registrations.pop(handler, None)
+                self._handler_guards.pop(handler, None)
+            return
         try:
             self.ee.remove_listener(msg_type, handler)
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
-    "ovos-spec-tools>=0.5.1a1",
+    "ovos-spec-tools>=0.9.0a1",
 ]
 
 [project.urls]

--- a/test/unittests/test_fakebus_namespace_migration.py
+++ b/test/unittests/test_fakebus_namespace_migration.py
@@ -1,0 +1,68 @@
+"""FakeBus mirrors MessageBusClient's legacy<->ovos.* namespace migration, so
+e2e/satellite tests exercise the real cross-namespace behaviour."""
+import unittest
+
+from ovos_utils.fakebus import FakeBus, Message
+
+
+class TestFakeBusNamespaceMigration(unittest.TestCase):
+    def test_legacy_emit_reaches_spec_listener(self):
+        bus = FakeBus()  # both flags default on
+        got = []
+        bus.on("ovos.utterance.speak", lambda m: got.append(m.msg_type))
+        bus.emit(Message("speak", {"utterance": "hi"}))
+        self.assertEqual(got, ["ovos.utterance.speak"])  # modernize bridged it
+
+    def test_spec_emit_reaches_legacy_listener(self):
+        bus = FakeBus()
+        got = []
+        bus.on("speak", lambda m: got.append(m.msg_type))
+        bus.emit(Message("ovos.utterance.speak", {"utterance": "hi"}))
+        self.assertEqual(got, ["speak"])  # emit_legacy bridged it
+
+    def test_dual_listener_fires_once(self):
+        bus = FakeBus()
+        calls = []
+        handler = lambda m: calls.append(m.msg_type)
+        bus.on("speak", handler)
+        bus.on("ovos.utterance.speak", handler)
+        bus.emit(Message("speak", {"utterance": "hi"}))
+        self.assertEqual(len(calls), 1)  # mirror deduped
+
+    def test_distinct_listeners_each_fire_once(self):
+        bus = FakeBus()
+        legacy, spec = [], []
+        bus.on("speak", lambda m: legacy.append(1))
+        bus.on("ovos.utterance.speak", lambda m: spec.append(1))
+        bus.emit(Message("speak", {"utterance": "hi"}))
+        self.assertEqual((len(legacy), len(spec)), (1, 1))
+
+    def test_flags_off_no_bridging(self):
+        bus = FakeBus(modernize=False, emit_legacy=False)
+        got = []
+        bus.on("ovos.utterance.speak", lambda m: got.append(m.msg_type))
+        bus.emit(Message("speak", {"utterance": "hi"}))
+        self.assertEqual(got, [])  # no translation -> spec listener not reached
+
+    def test_unmapped_topic_untouched(self):
+        bus = FakeBus()
+        got = []
+        bus.on("my.custom.topic", lambda m: got.append(m.msg_type))
+        bus.emit(Message("my.custom.topic", {"x": 1}))
+        self.assertEqual(got, ["my.custom.topic"])
+
+    def test_remove_cleans_up(self):
+        bus = FakeBus()
+        calls = []
+        handler = lambda m: calls.append(1)
+        bus.on("speak", handler)
+        bus.on("ovos.utterance.speak", handler)
+        bus.remove("speak", handler)
+        bus.remove("ovos.utterance.speak", handler)
+        self.assertNotIn(handler, bus._handler_guards)
+        bus.emit(Message("speak", {"utterance": "hi"}))
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
FakeBus is a drop-in for `MessageBusClient` but lacked the namespace-migration translation, so e2e/satellite tests using it did NOT exercise the real cross-namespace behaviour (this is why ovoscope's audio harness had to be hand-migrated to spec topics).

Now FakeBus uses the **same** `ovos_spec_tools.NamespaceTranslator` as `MessageBusClient`: `emit()` also dispatches the counterpart topic(s) per the flags; `on()` wraps migrated-topic handlers with the shared mirror-guard so a handler on both namespaces fires once; `remove()` tears it down. Both flags default **on**; override with `FakeBus(modernize=False, emit_legacy=False)`. 7 unit tests cover both bridging directions, dedup, distinct-listeners, flags-off, remove. Stacked on ovos-spec-tools#26.