### PR TITLE
fix: raise ovos-spec-tools floor to 0.10.0a1 for NamespaceTranslator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
-    "ovos-spec-tools>=0.9.0a1",
+    "ovos-spec-tools>=0.10.0a1",
 ]
 
 [project.urls]


### PR DESCRIPTION
`ovos_utils/fakebus.py` imports `NamespaceTranslator` from `ovos_spec_tools` at module top level (unconditional):

```python
from ovos_spec_tools import NamespaceTranslator
```

That symbol first ships in **ovos-spec-tools 0.10.0a1** (PR #28 / the FakeBus namespace-migration work in #381). The dependency floor was still `>=0.9.0a1`, which can resolve to a version without `NamespaceTranslator` and break `import ovos_utils.fakebus` at runtime. This raises the floor to the version that actually provides the imported symbol.

Surfaced while finalizing ovoscope #92 (audio harness on the ovos.* spec namespace), which depends on this FakeBus bridging via `ovos-utils>=0.12.0a1`.