### PR TITLE
fix: translate mirrored payload onto counterpart topic in FakeBus

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,4 +12,6 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'extras'
+      # in-flight cross-dep: spec-tools translate_payload (PR #42) not yet published
+      pre_install_pip: 'git+https://github.com/OpenVoiceOS/ovos-spec-tools@fix/conformance-message'
       test_path: 'test/unittests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,4 +14,6 @@ jobs:
       coverage_source: 'ovos_utils'
       test_path: 'test/unittests'
       install_extras: '.[extras]'
+      # in-flight cross-dep: spec-tools translate_payload (PR #42) not yet published
+      pre_install_pip: 'git+https://github.com/OpenVoiceOS/ovos-spec-tools@fix/conformance-message'
       min_coverage: 0

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -76,10 +76,17 @@ class FakeBus:
         except Exception as e:
             LOG.exception(f"Error in event handler for '{message.msg_type}': {e}")
         # namespace migration: also dispatch the counterpart topic(s) so a
-        # listener on either namespace receives the event (consumers dedupe)
+        # listener on either namespace receives the event (consumers dedupe).
+        # the mirrored payload is reshaped into the counterpart topic's shape
+        # (identity for payload-compatible renames, a per-topic transform for
+        # shape-changing ones) so a listener on it receives the payload in *its*
+        # shape -- matching MessageBusClient's bridge.
         for topic in self._translator.counterpart_topics(message.msg_type):
             try:
-                self.ee.emit(topic, message.forward(topic, message.data))
+                translated = self._translator.translate_payload(
+                    from_topic=message.msg_type, to_topic=topic,
+                    data=message.data)
+                self.ee.emit(topic, message.forward(topic, translated))
             except Exception as e:
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
         self.on_message(message.serialize())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
-    "ovos-spec-tools>=0.14.1a1",
+    "ovos-spec-tools>=0.14.0a1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
-    "ovos-spec-tools>=0.10.0a1",
+    "ovos-spec-tools>=0.14.1a1",
 ]
 
 [project.urls]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,4 +7,4 @@ pyee>=8.0.0
 combo-lock~=0.2
 rich-click~=1.7
 rich~=13.7
-ovos-spec-tools>=0.14.1a1
+ovos-spec-tools>=0.14.0a1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,4 +7,4 @@ pyee>=8.0.0
 combo-lock~=0.2
 rich-click~=1.7
 rich~=13.7
-ovos-spec-tools>=0.5.1a1
+ovos-spec-tools>=0.14.1a1

--- a/test/unittests/test_fakebus_namespace_migration.py
+++ b/test/unittests/test_fakebus_namespace_migration.py
@@ -51,6 +51,34 @@ class TestFakeBusNamespaceMigration(unittest.TestCase):
         bus.emit(Message("my.custom.topic", {"x": 1}))
         self.assertEqual(got, ["my.custom.topic"])
 
+    def test_shape_changing_payload_reshaped_for_spec_listener(self):
+        # a spec listener on the counterpart of a SHAPE-CHANGING legacy topic
+        # receives the payload in ITS shape, not a verbatim legacy copy.
+        bus = FakeBus()
+        got = []
+        bus.on("ovos.intent.handler.start", lambda m: got.append(dict(m.data)))
+        bus.emit(Message("mycroft.skill.handler.start", {"handler": "HelloIntent"}))
+        self.assertEqual(len(got), 1)
+        # reshaped to the spec shape ({"intent_name": ...}), NOT {"handler": ...}
+        self.assertEqual(got[0], {"intent_name": "HelloIntent"})
+        self.assertNotIn("handler", got[0])
+
+    def test_shape_changing_payload_reshaped_for_legacy_listener(self):
+        bus = FakeBus()
+        got = []
+        bus.on("mycroft.skill.handler.start", lambda m: got.append(dict(m.data)))
+        bus.emit(Message("ovos.intent.handler.start",
+                         {"skill_id": "skill.foo", "intent_name": "HelloIntent"}))
+        self.assertEqual(len(got), 1)
+        self.assertEqual(got[0].get("handler"), "HelloIntent")  # legacy shape
+
+    def test_payload_compatible_rename_delivered_equivalent(self):
+        bus = FakeBus()
+        got = []
+        bus.on("ovos.utterance.speak", lambda m: got.append(dict(m.data)))
+        bus.emit(Message("speak", {"utterance": "hi", "lang": "en-us"}))
+        self.assertEqual(got, [{"utterance": "hi", "lang": "en-us"}])  # identity
+
     def test_remove_cleans_up(self):
         bus = FakeBus()
         calls = []


### PR DESCRIPTION
## What

`FakeBus` mirrors `MessageBusClient`'s legacy↔`ovos.*` namespace-migration bridge so e2e/satellite tests exercise the real cross-namespace behaviour. It now applies the **same** payload translation as the real bus: at its counterpart-emit point it calls the new `NamespaceTranslator.translate_payload(from_topic, to_topic, data)` API instead of forwarding `message.data` verbatim.

Bridge call-site (`ovos_utils/fakebus.py`, `FakeBus.emit`):

```python
for topic in self._translator.counterpart_topics(message.msg_type):
    translated = self._translator.translate_payload(
        from_topic=message.msg_type, to_topic=topic, data=message.data)
    self.ee.emit(topic, message.forward(topic, translated))
```

This keeps the test double faithful to the production bus (companion change: ovos-bus-client#235).

## Behaviour

- **payload-compatible renames** → identity transform; behaviour unchanged.
- **shape-changing renames** (handler trio, `detach_intent`, `enable`/`disable_intent`) → reshaped per direction.

## Test

`test/unittests/test_fakebus_namespace_migration.py` adds three cases. The key one: a listener on `ovos.intent.handler.start` (spec counterpart of the shape-changing legacy `mycroft.skill.handler.start`) receives `m.data == {"intent_name": "HelloIntent"}` when `{"handler": "HelloIntent"}` is emitted — the reshaped spec payload, not the verbatim legacy `{"handler": ...}` (asserts `"handler"` absent). The reverse direction and a payload-compatible identity case are also covered.

## Floor pin

Pins `ovos-spec-tools>=0.14.1a1` (pyproject + requirements/requirements.txt) — the `translate_payload` API ships in **ovos-spec-tools#42** (`fix/conformance-message`, OPEN, not yet published). **The floor must match #42's actual published version.** #42's branch `version.py` reads `0.12.0a3` but is behind spec-tools `dev` (`0.14.0a1`); the merge-triggered `fix:` release will be `0.14.1a1`. Correct this pin if that differs. Do not merge until #42 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)