### PR TITLE
fix: drop deprecated make_default from FakeBus default-session sync

### DIFF
--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -156,7 +156,10 @@ class FakeBus:
             from ovos_bus_client.session import Session, SessionManager
             new_session = message.data["session_data"]
             sess = Session.deserialize(new_session)
-            SessionManager.update(sess, make_default=True)
+            # payload is default_session.serialize() (id == "default"); the
+            # SessionManager singleton syncs default_session by id, so the
+            # deprecated make_default flag is not needed.
+            SessionManager.update(sess)
             LOG.debug("synced default_session")
         except ImportError:
             pass  # don't care
@@ -506,7 +509,10 @@ class AsyncFakeBus:
             from ovos_bus_client.session import Session, SessionManager
             new_session = message.data["session_data"]
             sess = Session.deserialize(new_session)
-            SessionManager.update(sess, make_default=True)
+            # payload is default_session.serialize() (id == "default"); the
+            # SessionManager singleton syncs default_session by id, so the
+            # deprecated make_default flag is not needed.
+            SessionManager.update(sess)
             LOG.debug("synced default_session")
         except ImportError:
             pass  # don't care


### PR DESCRIPTION
Companion to OpenVoiceOS/ovos-bus-client#249, which deprecates `SessionManager.update(make_default=True)`.

`FakeBus.on_default_session_update` (two sites) mirrors the real `MessageBusClient`'s default-session side effects. The `ovos.session.update_default` payload is `default_session.serialize()` — it already carries `session_id == "default"` — so plain `update(sess)` syncs the default identically through the singleton store, **without** emitting the new deprecation warning on every FakeBus default sync (which would otherwise spam the e2e suites).

Safe regardless of installed bus-client version: even pre-singleton `update()` syncs `default_session` when the session id is `"default"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)