### PR TITLE
fix: target a real shape-changing pair in namespace-migration tests

### DIFF
--- a/test/unittests/test_async_fakebus.py
+++ b/test/unittests/test_async_fakebus.py
@@ -217,14 +217,14 @@ class TestAsyncFakeBusNamespaceMigration(unittest.TestCase):
 
     def test_counterpart_payload_is_translated(self):
         # a spec listener on the counterpart of a SHAPE-CHANGING legacy topic
-        # receives the payload reshaped into ITS shape.
+        # receives the payload reshaped into ITS shape. detach_intent ->
+        # ovos.intent.deregister splits "skill:intent" into skill_id/intent_name.
         bus = AsyncFakeBus()
         got = []
-        bus.on("ovos.intent.handler.start", lambda m: got.append(dict(m.data)))
-        _run(bus.emit(FakeMessage("mycroft.skill.handler.start",
-                                  {"handler": "HelloIntent"})))
-        self.assertEqual(got, [{"intent_name": "HelloIntent"}])
-        self.assertNotIn("handler", got[0])
+        bus.on("ovos.intent.deregister", lambda m: got.append(dict(m.data)))
+        _run(bus.emit(FakeMessage("detach_intent",
+                                  {"intent_name": "skill.foo:HelloIntent"})))
+        self.assertEqual(got, [{"skill_id": "skill.foo", "intent_name": "HelloIntent"}])
 
     def test_dual_listener_fires_once(self):
         bus = AsyncFakeBus()

--- a/test/unittests/test_fakebus_namespace_migration.py
+++ b/test/unittests/test_fakebus_namespace_migration.py
@@ -60,23 +60,24 @@ class TestFakeBusNamespaceMigration(unittest.TestCase):
     def test_shape_changing_payload_reshaped_for_spec_listener(self):
         # a spec listener on the counterpart of a SHAPE-CHANGING legacy topic
         # receives the payload in ITS shape, not a verbatim legacy copy.
+        # detach_intent -> ovos.intent.deregister splits the compound
+        # "skill:intent" name into skill_id + intent_name.
         bus = FakeBus()
         got = []
-        bus.on("ovos.intent.handler.start", lambda m: got.append(dict(m.data)))
-        bus.emit(Message("mycroft.skill.handler.start", {"handler": "HelloIntent"}))
+        bus.on("ovos.intent.deregister", lambda m: got.append(dict(m.data)))
+        bus.emit(Message("detach_intent", {"intent_name": "skill.foo:HelloIntent"}))
         self.assertEqual(len(got), 1)
-        # reshaped to the spec shape ({"intent_name": ...}), NOT {"handler": ...}
-        self.assertEqual(got[0], {"intent_name": "HelloIntent"})
-        self.assertNotIn("handler", got[0])
+        self.assertEqual(got[0], {"skill_id": "skill.foo", "intent_name": "HelloIntent"})
 
     def test_shape_changing_payload_reshaped_for_legacy_listener(self):
         bus = FakeBus()
         got = []
-        bus.on("mycroft.skill.handler.start", lambda m: got.append(dict(m.data)))
-        bus.emit(Message("ovos.intent.handler.start",
+        bus.on("detach_intent", lambda m: got.append(dict(m.data)))
+        bus.emit(Message("ovos.intent.deregister",
                          {"skill_id": "skill.foo", "intent_name": "HelloIntent"}))
         self.assertEqual(len(got), 1)
-        self.assertEqual(got[0].get("handler"), "HelloIntent")  # legacy shape
+        # rejoined to the legacy compound shape
+        self.assertEqual(got[0].get("intent_name"), "skill.foo:HelloIntent")
 
     def test_payload_compatible_rename_delivered_equivalent(self):
         bus = FakeBus()


### PR DESCRIPTION
Three FakeBus namespace-migration tests (`test_fakebus_namespace_migration.py` ×2, `test_async_fakebus.py` ×1) asserted a `mycroft.skill.handler.* ↔ ovos.intent.handler.*` shape-changing migration. That mapping **never belonged in the map** — the §8 handler-lifecycle trio (`ovos.intent.handler.start/complete/error`) is orchestrator-owned new spec topics, *not* a rename of the legacy workshop per-skill `mycroft.skill.handler.*` events. ovos-spec-tools correctly has no such entry, so the spec listener was never reached and the tests failed on `dev` (across all Python versions).

Retarget them at a genuine shape-changing pair from `MIGRATION_PAYLOAD_TRANSFORMS`: **`detach_intent` ↔ `ovos.intent.deregister`**, which splits the compound `"skill:intent"` name into `skill_id` + `intent_name` (and rejoins it in the reverse direction). Same reshape-mechanism coverage, against a mapping that actually exists.

Fixes the pre-existing `build_tests` / `coverage` red on `dev`; not specific to any one PR. Full unit suite green locally (932 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)