### PR TITLE
fix: FakeBus folds the default session like any other (drop owner-only)

### DIFF
--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -145,9 +145,10 @@ class FakeBus:
         try:  # replicate side effects
             from ovos_bus_client.session import Session, SessionManager
             sess = Session.from_message(parsed_message)
-            if sess.session_id != "default":
-                # 'default' can only be updated by core
-                SessionManager.update(sess)
+            # every session — including the default id — folds onto the singleton
+            # (value-passing; nothing is owner-only, matching the spec-tools
+            # SessionManager and the real MessageBusClient)
+            SessionManager.update(sess)
         except ImportError:
             pass  # don't care
 
@@ -498,9 +499,10 @@ class AsyncFakeBus:
         try:  # replicate side effects
             from ovos_bus_client.session import Session, SessionManager
             sess = Session.from_message(parsed_message)
-            if sess.session_id != "default":
-                # 'default' can only be updated by core
-                SessionManager.update(sess)
+            # every session — including the default id — folds onto the singleton
+            # (value-passing; nothing is owner-only, matching the spec-tools
+            # SessionManager and the real MessageBusClient)
+            SessionManager.update(sess)
         except ImportError:
             pass  # don't care
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ extras = [
     "ovos-plugin-manager>=0.0.25",
     "ovos-config>=0.0.12",
     "ovos-workshop>=0.0.13",
-    "ovos_bus_client>=0.0.8",
+    "ovos_bus_client>=2.6.2a2",
     "langcodes",
     "timezonefinder",
     "oauthlib~=3.2",


### PR DESCRIPTION
Part of the session-correctness work (ovos-spec-tools #67+ / ovos-bus-client #254). `FakeBus.on_message` (sync + async) special-cased the `default` id as owner-only and refused to fold it. That contradicts SESSION-1 §4 (value-passing — nothing is owner-only) and the real `MessageBusClient` / spec-tools `SessionManager`. Drop the guard so every session, including the default, folds onto the singleton.

`FakeMessage` is the spec-tools `Message` re-export, so `forward`/`reply` session stamping is already inherited — no emit change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)