### PR TITLE
fix: FakeBus does not fold the default session on receive

### DIFF
--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -145,10 +145,14 @@ class FakeBus:
         try:  # replicate side effects
             from ovos_bus_client.session import Session, SessionManager
             sess = Session.from_message(parsed_message)
-            # every session — including the default id — folds onto the singleton
-            # (value-passing; nothing is owner-only, matching the spec-tools
-            # SessionManager and the real MessageBusClient)
-            SessionManager.update(sess)
+            if sess.session_id != "default":
+                # 'default' can only be updated by core — matching the real
+                # MessageBusClient.on_message, which never folds the default
+                # session on receive (only the explicit ovos.session.update_default
+                # broadcast updates it). Folding a stale token-less default
+                # snapshot back over the singleton would wipe in-place
+                # add_context mutations (e.g. intent-layer gating tokens).
+                SessionManager.update(sess)
         except ImportError:
             pass  # don't care
 
@@ -499,10 +503,14 @@ class AsyncFakeBus:
         try:  # replicate side effects
             from ovos_bus_client.session import Session, SessionManager
             sess = Session.from_message(parsed_message)
-            # every session — including the default id — folds onto the singleton
-            # (value-passing; nothing is owner-only, matching the spec-tools
-            # SessionManager and the real MessageBusClient)
-            SessionManager.update(sess)
+            if sess.session_id != "default":
+                # 'default' can only be updated by core — matching the real
+                # MessageBusClient.on_message, which never folds the default
+                # session on receive (only the explicit ovos.session.update_default
+                # broadcast updates it). Folding a stale token-less default
+                # snapshot back over the singleton would wipe in-place
+                # add_context mutations (e.g. intent-layer gating tokens).
+                SessionManager.update(sess)
         except ImportError:
             pass  # don't care
 


### PR DESCRIPTION
Restores the `if sess.session_id != "default"` guard in `FakeBus.on_message` / `AsyncFakeBus.on_message` that #393 (commit `9317a8d`) dropped.

## Root cause

#393's message claimed to *match the real `MessageBusClient`*, but the real `MessageBusClient.on_message` **still guards the default id** (ovos-bus-client 2.6.2a2, line 263):

```python
sess = Session.from_message(parsed_message)
if sess.session_id != "default":   # 'default' can only be updated by core
    SessionManager.update(sess)
```

Only the explicit `ovos.session.update_default` broadcast updates the default session. By dropping the guard, FakeBus diverged from production and **folds the default session on every received message**, wholesale-replacing the singleton's `context` with the incoming message's (pre-mutation) snapshot via `Session.update_from`.

This silently wipes every in-place `add_context` mutation the instant the next message is received — `handle_add_context` injects the token into the singleton's `context`, and FakeBus's `emit` then runs `on_message` on the *same* `add_context` message, folding its own pre-injection (token-less) snapshot back over the singleton.

## What it breaks

Intent-layer gating (ovos-workshop `IntentLayers`, refactored to context-gating in OpenVoiceOS/ovos-workshop#427). `activate_layer()` calls `set_context()` -> `add_context` -> `handle_add_context` injects the `layer_<name>` token -> the very next emitted message folds a token-less default session snapshot and discards it -> gated intents never match. The two `test_intent_layers_e2e.py` tests started XFAILing right after `9317a8d` landed (2026-06-29), inside the same singleton-registry refactor window as ovos-bus-client 2.6.2a1/a2.

```
after _utter('begin'): reached=['begin'] active_layers=['demo-layers.test:layer0']
post-begin TOKENS=[]           <- token injected by handle_add_context, then wiped by the next fold
layer0 token present: False
```

## Fix

Restore the guard so FakeBus matches the real bus: the default session is never folded on receive. Verified locally:

```
post-begin TOKENS=['layer_layer0']   <- token survives
layer0 token present: True
```

and the full `ovos-workshop/test/unittests/skills/test_intent_layers_e2e.py` suite passes (both tests, previously XFAIL).

Production is unaffected (the real bus already guarded) — this is purely a test-harness divergence regression. No behavior change for non-default sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)