### PR TITLE
fix: FakeBus folds the message session BEFORE handlers, not after

### DIFF
--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -110,6 +110,17 @@ class FakeBus:
                 message.context["session"] = sess.serialize()
             except ImportError:  # don't care
                 message.context["session"] = {"session_id": self.session_id}
+        # Fold the incoming message's session onto the SessionManager singleton
+        # BEFORE running handlers, matching the real MessageBusClient.on_message
+        # order (receive -> fold -> dispatch to handlers). Folding AFTER handlers
+        # would wipe any in-place / synced session mutation the handlers made
+        # (handle_session_sync merging intent_context, handle_add_context injecting
+        # context frames, ...), because the message's session snapshot was
+        # stamped at emit-time, before those mutations landed — a spec-violating
+        # self-broadcast-back wipe. The single-process harness has no separate
+        # receiver, so it must not re-fold its own emit once the handlers have
+        # run.
+        self.on_message(message.serialize())
         self.ee.emit("message", message.serialize())
         try:
             self.ee.emit(message.msg_type, message)
@@ -129,7 +140,6 @@ class FakeBus:
                 self.ee.emit(topic, message.forward(topic, translated))
             except Exception as e:
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
-        self.on_message(message.serialize())
 
     def on_message(self, *args):
         """
@@ -464,6 +474,10 @@ class AsyncFakeBus:
                 message.context["session"] = sess.serialize()
             except ImportError:  # don't care
                 message.context["session"] = {"session_id": self.session_id}
+        # Fold BEFORE handlers — see FakeBus.emit for the rationale (a post-
+        # handler self-broadcast-back fold wipes the handlers' in-place / synced
+        # session mutations with the stale emit-time snapshot).
+        self.on_message(message.serialize())
         self.ee.emit("message", message.serialize())
         try:
             self.ee.emit(message.msg_type, message)
@@ -479,7 +493,6 @@ class AsyncFakeBus:
                 self.ee.emit(topic, message.forward(topic, translated))
             except Exception as e:
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
-        self.on_message(message.serialize())
 
     # ------------------------------------------------------------------
     # Sync helpers used internally — same as FakeBus


### PR DESCRIPTION
Supersedes the withdrawn guard PR #395 with a spec-faithful fix.

## Root cause

\`FakeBus.emit\` stamped the message's session at emit time, ran the bus handlers (which may mutate the \`SessionManager\` singleton in place — \`handle_add_context\` injecting context frames, \`handle_session_sync\` merging \`intent_context\`, …), and **THEN** called \`on_message\` to fold that same message's session snapshot back onto the singleton. Because the snapshot was stamped **before** the handlers ran, the post-handler fold wholesale-replaced the singleton's state (\`Session.update_from\` is last-writer-wins per field per OVOS-SESSION-1 §2) with a pre-mutation snapshot — silently wiping every in-place / synced mutation the handlers just made.

This breaks any consumer relying on handler-side session mutations. Most visibly, ovos-workshop \`IntentLayers\` (intent-layer gating via the legacy \`add_context\` -> \`sess.context\` frame mechanism): \`activate_layer()\` injected the layer token into the default-session singleton, the originating utterance's own post-handler fold then wiped it, and gated intents never matched. Two \`test_intent_layers_e2e.py\` tests regressed to \`xfail\` at the same time the SessionManager singleton-registry fold landed.

## Fix

The real \`MessageBusClient.on_message\` folds **first** and dispatches to handlers **after** (receive -> fold -> handle). \`FakeBus.emit\` did the reverse. Reorder \`FakeBus\`/\`AsyncFakeBus.emit\` to fold \`on_message\` **before** running handlers, and drop the trailing post-handler \`on_message\` fold (a single-process harness has no separate receiver: re-folding its own emit after the handlers have run is the spec-violating self-broadcast-back wipe). With the receive-order fold the singleton reflects the incoming snapshot before handlers mutate it, and those mutations survive to the next message.

## Why this is spec-faithful and backward compatible

- Every session — default included — still folds (no owner-only guard; honors OVOS-CONTEXT-1 §4 / OVOS-SESSION-1).
- The legacy \`add_context\` -> \`sess.context\` frame mechanism works again under folding.
- Un-breaks the ovos-workshop intent-layers e2e suite **without any workshop-side change** (verified locally: both \`test_intent_layers_e2e.py\` tests pass with only this fix; released ovos-adapt-parser, no bridge).

The earlier guard-based attempt (#395) was correctly rejected as against the spec; this is the spec-aligned alternative.

## Verification

- \`test_fakebus.py\`, \`test_async_fakebus.py\`, \`test_fakebus_namespace_migration.py\`: 64 passed.
- ovos-workshop\`test_intent_layers_e2e.py\`: both tests pass (was xfail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)