### PR TITLE
fix: log each unique deprecation warning only once

### DIFF
--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -258,6 +258,11 @@ def get_logs_config(service_name: Optional[str] = None,
     return _logs_conf
 
 
+# Tracks (message, caller) pairs already logged so each unique deprecation
+# is only reported once instead of spamming the logs on every call
+_logged_deprecations = set()
+
+
 def log_deprecation(log_message: str = "DEPRECATED",
                     deprecation_version: str = "Unknown",
                     func_name: str = None,
@@ -297,6 +302,11 @@ def log_deprecation(log_message: str = "DEPRECATED",
         if not name.startswith(origin_module):
             call_info = f"{name}:{call.lineno}"
             break
+    # Only log each unique deprecation (message + caller) once
+    dedupe_key = (log_message, log_name, call_info)
+    if dedupe_key in _logged_deprecations:
+        return
+    _logged_deprecations.add(dedupe_key)
     # Explicitly format log to print origin log reference
     LOG.create_logger(log_name).warning(
         f"Deprecation version={deprecation_version}. Caller={call_info}. "

--- a/test/unittests/test_log.py
+++ b/test/unittests/test_log.py
@@ -184,6 +184,39 @@ class TestLog(unittest.TestCase):
         self.assertIn('version=1.0.0', log_msg, log_msg)
         self.assertIn('test deprecation', log_msg, log_msg)
 
+    @patch("ovos_utils.log.LOG.create_logger")
+    def test_log_deprecation_dedupe(self, create_logger):
+        fake_log = Mock()
+        log_warning = fake_log.warning
+        create_logger.return_value = fake_log
+        import ovos_utils.log
+        from ovos_utils.log import log_deprecation, deprecated
+        ovos_utils.log._logged_deprecations.clear()
+
+        # Repeated calls from the same caller only log once
+        for _ in range(10):
+            log_deprecation("repeated deprecation")
+        log_warning.assert_called_once()
+        log_msg = log_warning.call_args[0][0]
+        self.assertIn('repeated deprecation', log_msg, log_msg)
+
+        # A different message still logs
+        log_deprecation("other deprecation")
+        self.assertEqual(log_warning.call_count, 2)
+        log_msg = log_warning.call_args[0][0]
+        self.assertIn('other deprecation', log_msg, log_msg)
+
+        # Deprecated decorator is also deduplicated
+        @deprecated("decorated deprecation", "1.0.0")
+        def _deprecated_function():
+            pass
+
+        for _ in range(10):
+            _deprecated_function()
+        self.assertEqual(log_warning.call_count, 3)
+        log_msg = log_warning.call_args[0][0]
+        self.assertIn('decorated deprecation', log_msg, log_msg)
+
     @patch("ovos_utils.log.get_logs_config")
     @patch("ovos_utils.log.LOG")
     def test_monitor_log_level(self, log, get_config):


### PR DESCRIPTION
## Summary
`log_deprecation` and the `@deprecated` decorator emit a warning on every call. When a deprecated helper is invoked in a loop (e.g. per template line during skill loading), this floods the logs with thousands of identical deprecation lines in a single service boot.

This deduplicates deprecation logging per unique (message, caller location): the first occurrence is logged exactly as before (same level, format and caller attribution) and subsequent identical occurrences are suppressed. The `@deprecated` decorator goes through `log_deprecation`, so both paths are covered at the common choke point. Public signatures are unchanged.

## Testing
Adds `test_log_deprecation_dedupe`, asserting that repeated calls with the same message from the same caller produce exactly one log record, that a different message still logs, and that the decorator path is deduplicated too. Full unit test suite passes locally (933 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)