### PR TITLE
fix: ovos-logs CLI leaves stray file in cwd

### DIFF
--- a/ovos_utils/log_parser.py
+++ b/ovos_utils/log_parser.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.style import Style
 from rich.table import Table
 import pydoc
-from combo_lock import ComboLock
+from combo_lock import NamedLock
 
 try:
     from ovos_config import Configuration
@@ -25,7 +25,7 @@ from ovos_utils.log import get_log_path, get_log_paths, get_available_logs
 
 
 TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
-LOGLOCK = ComboLock("ovos_logs_console_script")
+LOGLOCK = NamedLock("ovos_logs_console_script")
 
 
 @dataclass

--- a/test/unittests/test_log_parser.py
+++ b/test/unittests/test_log_parser.py
@@ -412,5 +412,52 @@ class TestGetLastLoadTime(unittest.TestCase):
         self.assertGreater(result, datetime.fromtimestamp(0))
 
 
+class TestOvosLogsCLINoStrayFiles(unittest.TestCase):
+    """Regression test: importing/using the ovos-logs CLI must not create
+    a stray lock file in the current working directory.
+
+    Previously `LOGLOCK = ComboLock("ovos_logs_console_script")` was
+    instantiated at module import time with a bare relative path, which
+    made ComboLock create (and leave behind) an empty file named
+    `ovos_logs_console_script` in whatever directory the process was
+    started from.
+    """
+
+    def test_help_does_not_create_stray_file(self) -> None:
+        import subprocess
+        import sys
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            before = set(os.listdir(tmpdir))
+            subprocess.run(
+                [sys.executable, "-c",
+                 "import sys; sys.argv=['ovos-logs', '--help']; "
+                 "from ovos_utils.log_parser import ovos_logs; "
+                 "ovos_logs()"],
+                cwd=tmpdir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            after = set(os.listdir(tmpdir))
+        self.assertEqual(before, after,
+                          f"stray files created in cwd: {after - before}")
+
+    def test_importing_log_parser_does_not_create_stray_file(self) -> None:
+        import subprocess
+        import sys
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            before = set(os.listdir(tmpdir))
+            subprocess.run(
+                [sys.executable, "-c", "import ovos_utils.log_parser"],
+                cwd=tmpdir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            after = set(os.listdir(tmpdir))
+        self.assertEqual(before, after,
+                          f"stray files created in cwd: {after - before}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What was broken

Running `ovos-logs --help` (or any `ovos-logs` subcommand, or even just
importing `ovos_utils.log_parser`) creates an empty file named
`ovos_logs_console_script` in the current working directory.

## How it fails

`ovos_utils/log_parser.py` instantiates a module-level lock at import
time:

```python
LOGLOCK = ComboLock("ovos_logs_console_script")
```

`combo_lock.ComboLock.__init__` resolves its `path` argument relative
to the process cwd and unconditionally creates the file if it doesn't
already exist. Since the path passed here is a bare relative string
(not an absolute path in a proper runtime directory), the lock file
ends up created wherever the command happens to be invoked from, on
every run.

Reproduced in a clean scratch directory:

```
$ ls
$ ovos-logs --help > /dev/null
$ ls
ovos_logs_console_script
```

## The fix

Switch `LOGLOCK` from `combo_lock.ComboLock` to `combo_lock.NamedLock`,
which is the intended API for this use case: it resolves the lock file
into a proper runtime location (RAM disk / tempdir via
`get_ram_directory`) instead of the current working directory, so no
stray file is left behind in arbitrary directories.

## How it was verified

- Reproduced the bug against the unmodified code in a clean directory
  (file appears after `ovos-logs --help`).
- Confirmed the fix: running the CLI (and a bare module import) from a
  clean directory no longer creates the stray file.
- Added a regression test
  (`TestOvosLogsCLINoStrayFiles` in `test/unittests/test_log_parser.py`)
  that runs the CLI's `--help` and a bare `import ovos_utils.log_parser`
  via `subprocess` with `cwd` set to a temporary directory, asserting
  the directory's contents are unchanged before/after.
- Ran the full `test/unittests/test_log_parser.py` suite with
  `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`: 37 passed.

---
This PR was authored with AI assistance (Claude).