### PR TITLE
fix: replace removed distutils.spawn with shutil.which (Python 3.12+)

### DIFF
--- a/ovos_utils/device_input.py
+++ b/ovos_utils/device_input.py
@@ -1,5 +1,5 @@
 import subprocess
-from distutils.spawn import find_executable
+from shutil import which
 
 from ovos_utils.gui import is_gui_installed
 from ovos_utils.log import LOG
@@ -9,7 +9,7 @@ class InputDeviceHelper:
     def __init__(self) -> None:
         self.libinput_devices_list = []
         self.xinput_devices_list = []
-        if not find_executable("libinput") and not find_executable("xinput"):
+        if not which("libinput") and not which("xinput"):
             LOG.warning("Could not find libinput, input device detection will be inaccurate")
 
     # ToDo: add support for discovering the input device based of a connected
@@ -68,7 +68,7 @@ class InputDeviceHelper:
                  })
 
     def _get_libinput_devices_list(self):
-        if find_executable("libinput"):
+        if which("libinput"):
             try:
                 self._build_linput_devices_list()
             except Exception:
@@ -98,7 +98,7 @@ class InputDeviceHelper:
                 self.xinput_devices_list.append(dev)
 
     def _get_xinput_devices_list(self):
-        if find_executable("xinput"):
+        if which("xinput"):
             try:
                 self._build_xinput_devices_list()
             except Exception:
@@ -113,7 +113,7 @@ class InputDeviceHelper:
         return self.libinput_devices_list + self.xinput_devices_list
 
     def can_use_touch_mouse(self):
-        if not find_executable("libinput") and not find_executable("xinput"):
+        if not which("libinput") and not which("xinput"):
             # if gui installed assume we have a mouse
             # otherwise let's assume we are a server or something...
             return is_gui_installed()

--- a/ovos_utils/sound.py
+++ b/ovos_utils/sound.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from os.path import isfile
 from typing import Optional
 
-from distutils.spawn import find_executable
+from shutil import which
 
 from ovos_utils.log import LOG
 
@@ -39,28 +39,28 @@ def _find_player(uri):
     _, ext = os.path.splitext(uri)
 
     # scan installed executables that can handle playback
-    sox_play = find_executable("play")
+    sox_play = which("play")
     # sox should handle almost every format, but fails in some urls
     if sox_play:
         return sox_play + f" --type {ext} %1"
     # determine best available player
-    ogg123_play = find_executable("ogg123")
+    ogg123_play = which("ogg123")
     if "ogg" in ext and ogg123_play:
         return ogg123_play + " -q %1"
-    pw_play = find_executable("pw-play")
+    pw_play = which("pw-play")
     # pw_play handles both wav and mp3
     if pw_play:
         return pw_play + " %1"
     # wav file
     if 'wav' in ext:
-        pulse_play = find_executable("paplay")
+        pulse_play = which("paplay")
         if pulse_play:
             return pulse_play + " %1"
-        alsa_play = find_executable("aplay")
+        alsa_play = which("aplay")
         if alsa_play:
             return alsa_play + " %1"
     # guess mp3
-    mpg123_play = find_executable("mpg123")
+    mpg123_play = which("mpg123")
     if mpg123_play:
         return mpg123_play + " %1"
     LOG.error("Can't find player for: %s", uri)
@@ -135,14 +135,14 @@ def get_sound_duration(path: str, base_dir: Optional[str] = "") -> float:
             frames = f.getnframes()
             rate = f.getframerate()
         return frames / float(rate)
-    ffprobe = find_executable("ffprobe")
+    ffprobe = which("ffprobe")
     if ffprobe:
         args = (ffprobe, "-show_entries", "format=duration", "-i", path)
         popen = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         popen.wait()
         output = popen.stdout.read().decode("utf-8")
         return float(output.split("duration=")[-1].split("\n")[0])
-    media_info = find_executable("mediainfo")
+    media_info = which("mediainfo")
     if media_info:
         args = (media_info, path)
         popen = subprocess.Popen(args, stdout=subprocess.PIPE)

--- a/test/unittests/test_device_input.py
+++ b/test/unittests/test_device_input.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     distutils_stub = types.ModuleType("distutils")
     spawn_stub = types.ModuleType("distutils.spawn")
-    spawn_stub.find_executable = lambda x: None
+    spawn_stub.which = lambda x: None
     distutils_stub.spawn = spawn_stub
     sys.modules["distutils"] = distutils_stub
     sys.modules["distutils.spawn"] = spawn_stub
@@ -35,7 +35,7 @@ except ImportError:
 class TestInputDeviceHelper(unittest.TestCase):
     """Tests for InputDeviceHelper class."""
 
-    @patch("ovos_utils.device_input.find_executable", return_value=None)
+    @patch("ovos_utils.device_input.which", return_value=None)
     def test_init_no_executables(self, mock_find: MagicMock) -> None:
         """InputDeviceHelper should initialise with empty device lists."""
         from ovos_utils.device_input import InputDeviceHelper
@@ -43,7 +43,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         self.assertEqual(helper.libinput_devices_list, [])
         self.assertEqual(helper.xinput_devices_list, [])
 
-    @patch("ovos_utils.device_input.find_executable")
+    @patch("ovos_utils.device_input.which")
     @patch("subprocess.check_output")
     def test_build_libinput_devices_list(self, mock_output: MagicMock,
                                           mock_find: MagicMock) -> None:
@@ -63,7 +63,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         self.assertEqual(dev["Device"], "My Keyboard")
         self.assertIn("keyboard", dev["Capabilities"])
 
-    @patch("ovos_utils.device_input.find_executable")
+    @patch("ovos_utils.device_input.which")
     @patch("subprocess.check_output")
     def test_build_libinput_multiple_capabilities(self, mock_output: MagicMock,
                                                    mock_find: MagicMock) -> None:
@@ -82,7 +82,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         self.assertIsInstance(caps, list)
         self.assertGreater(len(caps), 1)
 
-    @patch("ovos_utils.device_input.find_executable")
+    @patch("ovos_utils.device_input.which")
     @patch("subprocess.check_output", side_effect=Exception("libinput failed"))
     def test_get_libinput_devices_exception(self, mock_output: MagicMock,
                                               mock_find: MagicMock) -> None:
@@ -93,7 +93,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         result = helper._get_libinput_devices_list()
         self.assertEqual(result, [])
 
-    @patch("ovos_utils.device_input.find_executable", return_value=None)
+    @patch("ovos_utils.device_input.which", return_value=None)
     def test_get_libinput_devices_no_executable(self, mock_find: MagicMock) -> None:
         """_get_libinput_devices_list should return empty list when libinput not found."""
         from ovos_utils.device_input import InputDeviceHelper
@@ -101,7 +101,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         result = helper._get_libinput_devices_list()
         self.assertEqual(result, [])
 
-    @patch("ovos_utils.device_input.find_executable")
+    @patch("ovos_utils.device_input.which")
     @patch("subprocess.check_output")
     def test_build_xinput_devices_list(self, mock_output: MagicMock,
                                         mock_find: MagicMock) -> None:
@@ -117,7 +117,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         helper._build_xinput_devices_list()
         self.assertGreater(len(helper.xinput_devices_list), 0)
 
-    @patch("ovos_utils.device_input.find_executable")
+    @patch("ovos_utils.device_input.which")
     @patch("subprocess.check_output", side_effect=Exception("xinput failed"))
     def test_get_xinput_devices_exception(self, mock_output: MagicMock,
                                            mock_find: MagicMock) -> None:
@@ -128,7 +128,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         result = helper._get_xinput_devices_list()
         self.assertEqual(result, [])
 
-    @patch("ovos_utils.device_input.find_executable", return_value=None)
+    @patch("ovos_utils.device_input.which", return_value=None)
     def test_get_xinput_devices_no_executable(self, mock_find: MagicMock) -> None:
         """_get_xinput_devices_list should return empty list when xinput not found."""
         from ovos_utils.device_input import InputDeviceHelper
@@ -136,7 +136,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         result = helper._get_xinput_devices_list()
         self.assertEqual(result, [])
 
-    @mock.patch("ovos_utils.device_input.find_executable")
+    @mock.patch("ovos_utils.device_input.which")
     def test_can_use_touch_mouse(self, find_exec: MagicMock) -> None:
         """can_use_touch_mouse should detect touch/mouse/tablet/pointer/gesture."""
         from ovos_utils.device_input import InputDeviceHelper
@@ -164,7 +164,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         dev_input.xinput_devices_list.pop()
         self.assertFalse(dev_input.can_use_touch_mouse())
 
-    @mock.patch("ovos_utils.device_input.find_executable")
+    @mock.patch("ovos_utils.device_input.which")
     def test_can_use_keyboard(self, find_exec: MagicMock) -> None:
         """can_use_keyboard should detect keyboard devices."""
         from ovos_utils.device_input import InputDeviceHelper
@@ -192,7 +192,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         dev_input.xinput_devices_list.pop()
         self.assertFalse(dev_input.can_use_keyboard())
 
-    @patch("ovos_utils.device_input.find_executable", return_value=None)
+    @patch("ovos_utils.device_input.which", return_value=None)
     @patch("ovos_utils.device_input.is_gui_installed", return_value=True)
     def test_can_use_touch_mouse_no_executable_gui_installed(
             self, mock_gui: MagicMock, mock_find: MagicMock) -> None:
@@ -202,7 +202,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         result = helper.can_use_touch_mouse()
         self.assertTrue(result)
 
-    @patch("ovos_utils.device_input.find_executable", return_value=None)
+    @patch("ovos_utils.device_input.which", return_value=None)
     @patch("ovos_utils.device_input.is_gui_installed", return_value=False)
     def test_can_use_touch_mouse_no_executable_no_gui(
             self, mock_gui: MagicMock, mock_find: MagicMock) -> None:
@@ -212,7 +212,7 @@ class TestInputDeviceHelper(unittest.TestCase):
         result = helper.can_use_touch_mouse()
         self.assertFalse(result)
 
-    @patch("ovos_utils.device_input.find_executable")
+    @patch("ovos_utils.device_input.which")
     def test_get_input_device_list(self, mock_find: MagicMock) -> None:
         """get_input_device_list should combine libinput and xinput device lists."""
         from ovos_utils.device_input import InputDeviceHelper

--- a/test/unittests/test_sound.py
+++ b/test/unittests/test_sound.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock, patch, mock_open
 if "distutils" not in sys.modules:
     distutils_stub = types.ModuleType("distutils")
     spawn_stub = types.ModuleType("distutils.spawn")
-    spawn_stub.find_executable = lambda x: None
+    spawn_stub.which = lambda x: None
     distutils_stub.spawn = spawn_stub
     sys.modules["distutils"] = distutils_stub
     sys.modules["distutils.spawn"] = spawn_stub
@@ -62,7 +62,7 @@ class TestGetPulseEnvironment(unittest.TestCase):
 class TestFindPlayer(unittest.TestCase):
     """Tests for _find_player helper."""
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     def test_sox_play_found(self, mock_find: MagicMock) -> None:
         """Should prefer sox play when available."""
         mock_find.side_effect = lambda x: "/usr/bin/play" if x == "play" else None
@@ -71,7 +71,7 @@ class TestFindPlayer(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("play", result)
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     def test_ogg_player_preferred_for_ogg(self, mock_find: MagicMock) -> None:
         """Should prefer ogg123 for .ogg files when sox is unavailable."""
         def side_effect(x: str) -> str | None:
@@ -86,7 +86,7 @@ class TestFindPlayer(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("ogg123", result)
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     def test_pw_play_fallback(self, mock_find: MagicMock) -> None:
         """Should use pw-play when sox is unavailable and file is not ogg."""
         def side_effect(x: str) -> str | None:
@@ -99,7 +99,7 @@ class TestFindPlayer(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("pw-play", result)
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     def test_paplay_for_wav(self, mock_find: MagicMock) -> None:
         """Should use paplay for .wav when pw-play and sox unavailable."""
         def side_effect(x: str) -> str | None:
@@ -112,7 +112,7 @@ class TestFindPlayer(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("paplay", result)
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     def test_aplay_for_wav_when_paplay_missing(self, mock_find: MagicMock) -> None:
         """Should fall back to aplay for .wav when paplay is unavailable."""
         def side_effect(x: str) -> str | None:
@@ -125,7 +125,7 @@ class TestFindPlayer(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("aplay", result)
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     def test_mpg123_for_mp3(self, mock_find: MagicMock) -> None:
         """Should use mpg123 for mp3 when no other player found."""
         def side_effect(x: str) -> str | None:
@@ -138,7 +138,7 @@ class TestFindPlayer(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("mpg123", result)
 
-    @patch("ovos_utils.sound.find_executable", return_value=None)
+    @patch("ovos_utils.sound.which", return_value=None)
     def test_returns_none_when_no_player(self, _mock_find: MagicMock) -> None:
         """Should return None when no suitable player is found."""
         from ovos_utils.sound import _find_player
@@ -287,7 +287,7 @@ class TestGetSoundDuration(unittest.TestCase):
             duration = get_sound_duration("snd/test.wav", base_dir=base_dir)
             self.assertGreater(duration, 0)
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     @patch("subprocess.Popen")
     def test_ffprobe_fallback(self, mock_popen: MagicMock,
                                mock_find: MagicMock) -> None:
@@ -311,7 +311,7 @@ class TestGetSoundDuration(unittest.TestCase):
         finally:
             os.unlink(fname)
 
-    @patch("ovos_utils.sound.find_executable")
+    @patch("ovos_utils.sound.which")
     @patch("subprocess.Popen")
     def test_mediainfo_fallback(self, mock_popen: MagicMock,
                                  mock_find: MagicMock) -> None:
@@ -337,7 +337,7 @@ class TestGetSoundDuration(unittest.TestCase):
         finally:
             os.unlink(fname)
 
-    @patch("ovos_utils.sound.find_executable", return_value=None)
+    @patch("ovos_utils.sound.which", return_value=None)
     def test_no_tool_raises_runtime_error(self, _mock_find: MagicMock) -> None:
         """get_sound_duration should raise RuntimeError when no tool is available."""
         with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:


### PR DESCRIPTION
## Problem

`distutils` was removed from the Python standard library in 3.12. This breaks import of two modules that still use it:

```
ModuleNotFoundError: No module named 'distutils'
```

Affected modules:
- `ovos_utils.sound` — uses `distutils.spawn.find_executable` to locate audio players (`play`, `ogg123`, `pw-play`, `paplay`, `aplay`, `mpg123`) and media probes (`ffprobe`, `mediainfo`)
- `ovos_utils.device_input` — uses `distutils.spawn.find_executable` to locate `libinput`/`xinput`

Both modules fail to import at all on Python 3.12+.

## Fix

Replace `from distutils.spawn import find_executable` with `from shutil import which`, and every `find_executable(...)` call with `which(...)`. `shutil.which` is the stdlib replacement recommended for this exact use case (same signature/behavior: returns the resolved path or `None`).

Existing unit tests (`test/unittests/test_sound.py`, `test/unittests/test_device_input.py`) patched `find_executable` by name, so those mock targets were updated to `which` as well. No behavior changes.

## Test plan
- [x] `ast.parse` sanity check on both edited modules
- [x] `grep -r distutils ovos_utils/` returns nothing
- [x] `pytest test/unittests/test_sound.py test/unittests/test_device_input.py` — 39 passed

---
This fix was authored with Claude Code.