### PR TITLE
refactor: deprecate create_self_signed_cert

### DIFF
--- a/ovos_utils/security.py
+++ b/ovos_utils/security.py
@@ -8,7 +8,8 @@ from socket import gethostname
 
 import pexpect
 
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
+from ovos_utils.version import VERSION_MAJOR
 
 try:
     # pycryptodomex
@@ -25,10 +26,21 @@ except ImportError:
     crypto = None
 
 
+@deprecated("create_self_signed_cert is unmaintained and generates a "
+            "1024-bit RSA / SHA-1 certificate that modern OpenSSL "
+            "(SECLEVEL=2, the Debian/Ubuntu/Fedora default) refuses to load "
+            "('EE_KEY_TOO_SMALL'). Callers should bundle their own "
+            "self-signed cert generation (RSA >= 2048, SHA-256, with a "
+            "Subject Alternative Name) instead of relying on this helper.",
+            f"{VERSION_MAJOR + 1}.0.0")
 def create_self_signed_cert(cert_dir, name="jarbas"):
     """
     If name.crt and name.key don't exist in cert_dir, create a new
     self-signed cert and key pair and write them into that directory.
+
+    .. deprecated:: unmaintained; generates a 1024-bit RSA / SHA-1
+        certificate that modern OpenSSL rejects at load time. Bundle your
+        own self-signed cert generation instead.
     """
     if crypto is None:
         LOG.error("run pip install pyopenssl")


### PR DESCRIPTION
## Summary

`create_self_signed_cert()` in `ovos_utils/security.py` generates a
1024-bit RSA key and signs the certificate with SHA-1. Modern OpenSSL
(OpenSSL 3's default security level, SECLEVEL=2 — the default on
Debian/Ubuntu/Fedora) refuses to load a certificate that weak.

Reproduced on OpenSSL 3.6.3:

```
openssl req -x509 -newkey rsa:1024 -sha1 -nodes -keyout w.key -out w.crt -days 1 -subj "/CN=test"
python3 -c "import ssl; c=ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER); c.load_cert_chain('w.crt','w.key')"
# -> ssl.SSLError: [SSL: EE_KEY_TOO_SMALL] ee key too small
```

So any caller that generates a cert with this helper and hands it to a
TLS server fails at load time.

## What this PR does (and does not do)

This helper doesn't belong long-term in `ovos-utils` — self-signed cert
generation is being bundled directly in `ovos-messagebus` instead
(see ovos-messagebus PR #66). So rather than fixing the crypto
parameters here, this PR **deprecates** `create_self_signed_cert()`
using the repo's existing `@deprecated` decorator
(`ovos_utils/log.py`) and its dynamic `VERSION_MAJOR + 1` removal-version
convention, matching how `bracket_expansion.py`, `dialog.py`, and
`system.py` already deprecate functions.

The function itself is **unchanged**: same signature, same 1024-bit
RSA/SHA-1 output, same file naming (`<name>.crt`/`<name>.key`), same
"reuse if already present" behaviour, same return value. Existing
callers keep working exactly as before — they just get a deprecation
log line pointing out the weak crypto and steering them toward bundling
their own generation.

Verified no in-org caller imports this function (checked OpenVoiceOS,
JarbasHiveMind, TigreGotico); the two HiveMind protocol packages already
carry their own vendored RSA-2048/SHA-256 implementations, so this
deprecation breaks nothing downstream.

### Pre-existing weak cert caveat

The "reuse if present" check means any machine that already generated a
cert with the old 1024-bit/SHA-1 code path will keep reusing that weak
cert/key pair even after this change — deprecating the generator doesn't
regenerate existing files. Flagging this for the maintainer to consider
(e.g. detecting an undersized existing key and regenerating) rather than
silently deleting a user's existing key material here.

## Testing

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/unittests/test_security.py test/unittests/test_security_extra.py -q
# 14 passed, 1 skipped
```

Full suite: 933 passed, 1 skipped, 2 pre-existing failures in
`test_log_parser.py` (`TestOvosLogsCLINoStrayFiles`, reproduced
identically against a pristine `origin/dev` checkout — unrelated to this
change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)