### PR TITLE
fix: FileEventHandler must only fire for the file it watches

### DIFF
--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -376,9 +376,13 @@ class FileWatcher:
         for file_path in files:
             if os.path.isfile(file_path):
                 watch_dir = dirname(file_path)
+                # a specific file was requested, only fire for that file
+                watched_file = file_path
             else:
                 watch_dir = file_path
-            self.observer.schedule(FileEventHandler(file_path, callback,
+                # a directory was requested, fire for any file inside it
+                watched_file = None
+            self.observer.schedule(FileEventHandler(watched_file, callback,
                                                     ignore_creation),
                                    watch_dir, recursive=recursive)
         self.observer.start()
@@ -398,17 +402,20 @@ try:
     from watchdog.events import FileSystemEventHandler
 
     class FileEventHandler(FileSystemEventHandler):
-        def __init__(self, file_path: str, callback: callable,
+        def __init__(self, file_path: Optional[str], callback: callable,
                      ignore_creation: bool = False):
             """
             Create a handler for file change events
-            @param file_path: file_path being watched Unused(?)
+            @param file_path: if set, the single file being watched; events
+                for any other file in the watched directory are ignored.
+                If None, this handler is watching a directory and events
+                for any file inside it are reported.
             @param callback: function to call on file change with modified file path
             @param ignore_creation: if True, only track file modification events
             """
             super().__init__()
             self._callback = callback
-            self._file_path = file_path
+            self._file_path = os.path.realpath(file_path) if file_path else None
             if ignore_creation:
                 self._events = ('modified')
             else:
@@ -416,8 +423,22 @@ try:
             self._changed_files = set()
             self._lock = RLock()
 
+        def _is_watched(self, src_path) -> bool:
+            """
+            Check if a reported event path refers to the file this handler
+            was asked to watch. Always True in directory-watch mode.
+            @param src_path: `event.src_path`, str or bytes depending on platform
+            """
+            if self._file_path is None:
+                return True
+            if isinstance(src_path, bytes):
+                src_path = src_path.decode()
+            return os.path.realpath(src_path) == self._file_path
+
         def on_any_event(self, event):
             if event.is_directory:
+                return
+            if not self._is_watched(event.src_path):
                 return
             with self._lock:
                 if event.event_type == "closed":

--- a/test/unittests/test_file_utils.py
+++ b/test/unittests/test_file_utils.py
@@ -169,6 +169,46 @@ class TestFileUtils(unittest.TestCase):
         handler.on_any_event(FileClosedEvent(test_file))
         callback.assert_called_once()
 
+        # Test events for a different file in the same directory are ignored
+        # when watching a specific file (the FileWatcher watches the
+        # containing directory, so watchdog reports every file inside it)
+        other_file = join(dirname(__file__), "other.watch")
+        callback.reset_mock()
+        handler = FileEventHandler(test_file, callback, True)
+        handler.on_any_event(FileModifiedEvent(other_file))
+        handler.on_any_event(FileClosedEvent(other_file))
+        callback.assert_not_called()
+        # but the watched file itself still fires
+        handler.on_any_event(FileModifiedEvent(test_file))
+        handler.on_any_event(FileClosedEvent(test_file))
+        callback.assert_called_once()
+
+        # Test directory-watch mode (file_path=None) reports every file
+        callback.reset_mock()
+        handler = FileEventHandler(None, callback, True)
+        handler.on_any_event(FileModifiedEvent(test_file))
+        handler.on_any_event(FileClosedEvent(test_file))
+        callback.assert_called_once_with(test_file)
+        callback.reset_mock()
+        handler.on_any_event(FileModifiedEvent(other_file))
+        handler.on_any_event(FileClosedEvent(other_file))
+        callback.assert_called_once_with(other_file)
+
+        # Test two handlers watching different files in the same directory
+        # each fire only for their own file, not for each other's
+        callback_a = Mock()
+        callback_b = Mock()
+        handler_a = FileEventHandler(test_file, callback_a, True)
+        handler_b = FileEventHandler(other_file, callback_b, True)
+        # both handlers watch the same directory, so watchdog delivers
+        # every event to both of them
+        for handler in (handler_a, handler_b):
+            for ev_file in (test_file, other_file):
+                handler.on_any_event(FileModifiedEvent(ev_file))
+                handler.on_any_event(FileClosedEvent(ev_file))
+        callback_a.assert_called_once_with(test_file)
+        callback_b.assert_called_once_with(other_file)
+
         # Test include creation callbacks
         callback.reset_mock()
         handler = FileEventHandler(test_file, callback, False)


### PR DESCRIPTION
## Bug

`FileEventHandler` stored the `file_path` it was constructed with but never
compared it against `event.src_path` in `on_any_event`. Since `FileWatcher`
schedules a directory-level watch whenever it is given a file (watching
`dirname(file_path)`), a watcher asked to watch one specific file was woken
by every unrelated file changing in that directory. Watching two files that
share a directory scheduled two handlers, each firing for both files -
duplicate callbacks.

`ovos-config`'s `ovos_config/utils.py` currently works around this by
deduplicating its watch list down to one entry per directory, purely to
avoid the duplicate-firing side effect.

## Fix

`FileWatcher.__init__` already distinguishes file-mode from directory-mode
via `os.path.isfile(file_path)`. It now passes the handler `None` in
directory mode (unchanged behavior: fire for anything inside), or the
specific file path in file mode. `FileEventHandler` normalizes both sides
with `os.path.realpath` (decoding `event.src_path` first if watchdog reports
it as `bytes`) and returns early on a mismatch, in both the `closed` branch
and the `created`/`modified` branch that populates `_changed_files`. Fixed
the misleading `Unused(?)` docstring.

Directory-watch mode (used by `ovos-workshop`'s `skill_launcher.py` and
`ovos-microphone-plugin-files`) is unchanged - confirmed by reading both
call sites and by the existing `test_filewatcher` directory-mode assertions,
which still pass unmodified.

With this fix, downstream callers (e.g. `ovos-config`) no longer need to
deduplicate their watch list by directory - they can go back to passing the
specific files they actually care about.

## Tests

Extended `test/unittests/test_file_utils.py::test_file_event_handler` with
synthetic watchdog events (no real-FS timing) covering:
- file mode: a change to the watched file still fires the callback
- file mode: a change to a *different* file in the same directory does
  **not** fire it (the regression this PR is about)
- directory mode (`file_path=None`): a change to any file inside still
  fires
- two handlers watching different files in the same directory each fire
  exactly once for their own file, never for the other's

Baseline (`origin/dev`, unmodified): `933 passed, 2 failed, 1 skipped` -
the 2 failures are `test_log_parser.py::TestOvosLogsCLINoStrayFiles`,
pre-existing and unrelated to this change.

This branch: same `933 passed, 2 failed (same 2), 1 skipped` - no
regressions, no net new test count change (assertions were added inside
the existing `test_file_event_handler` method).