### PR TITLE
fix: watch files that do not exist yet

### DIFF
--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -374,14 +374,21 @@ class FileWatcher:
         self.observer = Observer()
         self.handlers = []
         for file_path in files:
-            if os.path.isfile(file_path):
-                watch_dir = dirname(file_path)
-                # a specific file was requested, only fire for that file
-                watched_file = file_path
-            else:
+            if os.path.isdir(file_path):
                 watch_dir = file_path
                 # a directory was requested, fire for any file inside it
                 watched_file = None
+            else:
+                # a specific file was requested, only fire for that file.
+                # the file may not exist yet (eg. a config that hasn't been
+                # written), watchdog just needs its (existing) parent dir
+                watch_dir = dirname(file_path) or "."
+                watched_file = file_path
+                if not os.path.isdir(watch_dir):
+                    LOG.warning(f"Can't watch '{file_path}', "
+                                f"parent directory '{watch_dir}' "
+                                f"does not exist")
+                    continue
             self.observer.schedule(FileEventHandler(watched_file, callback,
                                                     ignore_creation),
                                    watch_dir, recursive=recursive)

--- a/test/unittests/test_file_utils.py
+++ b/test/unittests/test_file_utils.py
@@ -1,10 +1,11 @@
+import os
 import shutil
 import unittest
 from os import makedirs
 from os.path import isdir, join, dirname
 from threading import Event
 from time import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 
 class TestFileUtils(unittest.TestCase):
@@ -142,6 +143,58 @@ class TestFileUtils(unittest.TestCase):
         watcher.shutdown()
 
         shutil.rmtree(test_dir)
+
+    def test_filewatcher_not_yet_existing_file(self):
+        from ovos_utils.file_utils import FileWatcher
+
+        test_dir = join(dirname(__file__), "test_watch_new")
+        test_file = join(test_dir, "not_yet.watch")
+        makedirs(test_dir, exist_ok=True)
+        self.assertFalse(os.path.isfile(test_file))
+
+        # a path that doesn't exist yet is still watched in file mode:
+        # the containing (existing) directory is scheduled, and a
+        # 'created' event for the not-yet-existing file fires the callback
+        called = Event()
+        callback = Mock(side_effect=lambda x: called.set())
+        watcher = FileWatcher([test_file], callback)
+        with open(test_file, 'w+'):
+            pass
+        self.assertTrue(called.wait(3))
+        callback.assert_called_once_with(test_file)
+        watcher.shutdown()
+
+        # a different file being created in the same directory must
+        # NOT fire the callback (file mode still filters to the one path)
+        called.clear()
+        callback.reset_mock()
+        watcher = FileWatcher([test_file], callback)
+        other_file = join(test_dir, "other.watch")
+        with open(other_file, 'w+'):
+            pass
+        self.assertFalse(called.wait(3))
+        callback.assert_not_called()
+        watcher.shutdown()
+
+        shutil.rmtree(test_dir)
+
+    def test_filewatcher_missing_parent_directory(self):
+        from ovos_utils.file_utils import FileWatcher
+
+        # if the parent directory of a not-yet-existing file also doesn't
+        # exist, watchdog can't schedule an observer on it; FileWatcher
+        # must skip that entry (with a LOG.warning) instead of raising
+        # an opaque watchdog exception
+        missing_parent = join(dirname(__file__), "definitely_not_there")
+        missing_file = join(missing_parent, "cfg.json")
+        self.assertFalse(isdir(missing_parent))
+
+        callback = Mock()
+        with patch("ovos_utils.file_utils.LOG") as mock_log:
+            watcher = FileWatcher([missing_file], callback)
+            mock_log.warning.assert_called_once()
+        self.assertEqual(watcher.observer.emitters, set())
+        watcher.shutdown()
 
     def test_file_event_handler(self):
         from ovos_utils.file_utils import FileEventHandler


### PR DESCRIPTION
## Summary

`FileWatcher.__init__` chose file-mode vs directory-mode with `os.path.isfile(file_path)`. A path that does not exist yet is not a file, so it fell through to directory mode: `watch_dir` became the nonexistent path (which `watchdog` cannot schedule an observer on) and the handler ran unfiltered instead of being scoped to that single path.

Practical effect: `FileWatcher(["/some/dir/config.json"], cb)` could not detect the file being *created* later, even with the default `ignore_creation=False` whose whole point is to report `created` events. Callers were forced to either pre-create the file or watch the entire containing directory.

This is exactly what `ovos-config` PR #194 hit: it switched to watching specific config files, and a test that registers the watcher **before** writing `mycroft.conf` stopped firing, because the not-yet-existing file was silently dropped into directory mode.

## Fix

Dispatch on `os.path.isdir()` instead of `os.path.isfile()`:
- an existing directory → directory mode, unchanged behavior
- anything else (an existing file, or a path that doesn't exist yet) → file mode: watch the parent directory, filter to that single path. This is safe because of the per-file filtering added in #406 — the handler watches the parent dir but only fires for its own path.

If the **parent** directory also doesn't exist, `watchdog` can't schedule an observer on it either. Rather than let an opaque `watchdog` traceback propagate, that entry is skipped with `LOG.warning`.

## Consumers re-checked

- `ovos-workshop` `skill_launcher.py`: `FileWatcher([self.skill_directory], ...)` — existing directory, still lands in directory mode. Unaffected.
- `ovos-microphone-plugin-files`: `FileWatcher([self.files_folder], ...)` — same, unaffected.

This unblocks downstream consumers (e.g. `ovos-config`) that need to watch specific config files which may not exist yet at startup.

## Test plan
- [x] Path that doesn't exist yet is watched in file mode; a `created` event for it fires the callback, while a different file created in the same directory does not
- [x] Existing directory still watched in directory mode, fires for any file inside (pre-existing test, still passing)
- [x] Existing file still fires only for itself (pre-existing test, still passing)
- [x] Missing parent directory: entry is skipped with `LOG.warning`, no exception raised
- [x] Full suite: 935 passed (up from 933 baseline), same 2 pre-existing unrelated failures in `test_log_parser.py::TestOvosLogsCLINoStrayFiles`