### PR TITLE
feat: FakeBus mirrors the .intent-suffixed twin for aliased intents

### DIFF
--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -64,88 +64,49 @@ def _resolve_bus_flags(kwargs):
 # wire: a skill with ``food.order.intent`` listened on
 # ``<skill_id>:food.order.intent``. Current workshop is spec-pure and
 # registers the canonical ``<skill_id>:food.order`` (OVOS-MSG-1 §2.1.1).
-#
-# ``ovos_spec_tools.intent_topics`` is the whole compat surface for that gap.
-# It is newer than the spec-tools floor declared here, so the import is
-# guarded: against an older spec-tools the fake bus behaves as before.
-try:
-    from ovos_spec_tools.intent_topics import (IntentAliasRegistry,
-                                               legacy_reemit_targets)
-    _HAS_INTENT_TOPICS = True
-except ImportError:  # spec-tools without OVOS-INTENT-4 compat helpers
-    IntentAliasRegistry = None
-    legacy_reemit_targets = None
-    _HAS_INTENT_TOPICS = False
+from ovos_spec_tools.intent_topics import (canonical_intent_topic,
+                                           is_intent_topic,
+                                           legacy_intent_topic)
 
-#: Context flag stamped on a mirrored intent dispatch. A message carrying it is
-#: already a twin, so it is never mirrored again. Same key the real
-#: ``MessageBusClient`` uses.
-INTENT_REEMIT_CONTEXT_KEY = "__legacy_intent_reemit__"
+#: Context flag stamped on a twin intent frame. Same key and same meaning as
+#: in ``ovos_bus_client.client.client``.
+INTENT_COMPAT_TWIN_KEY = "_intent_compat_twin"
 
 
 class _LegacyIntentBridge:
-    """Mirror an intent dispatch onto its legacy ``.intent``-suffixed twin.
+    """Bridge the canonical and legacy spellings of an intent dispatch topic.
 
     Shared by :class:`FakeBus` and :class:`AsyncFakeBus` so both test doubles
     behave like ``ovos_bus_client.MessageBusClient``, which runs the same
     bridge next to its namespace bridge. A test double that skipped it would
     hide the compat path from every harness built on it.
 
-    The alias table is owned by the bus instance and filled from its own
-    ``on()`` / ``once()`` calls: a bus mirrors only the intents one of its own
-    handlers asked for by the suffixed name, so no topic nobody listens on is
-    invented.
+    The real client splits the bridge over a wire send and a wire receive. A
+    fake bus is one process, so both rules land in ``emit``:
+
+    * a CANONICAL dispatch also fires its ``.intent``-suffixed twin, marked as
+      a twin, reaching a handler written against old workshop;
+    * a SUFFIXED dispatch that is NOT already such a twin also fires its
+      canonical spelling, reaching a spec-pure handler.
+
+    The two cases are mutually exclusive and neither cascades, so one emit
+    reaches each handler exactly once. Nothing tracks who listens to what.
     """
 
-    def _init_intent_bridge(self, kwargs):
-        self._intent_aliases = IntentAliasRegistry() if _HAS_INTENT_TOPICS else None
-        blanket = kwargs.get("intent_reemit_blanket", _UNSET)
-        if blanket is _UNSET:
-            blanket = _bus_flag("OVOS_BUS_INTENT_REEMIT_BLANKET",
-                                "intent_reemit_blanket", default=False)
-        # blanket mode mirrors EVERY intent dispatch, registered alias or not,
-        # for pure-bus listeners that subscribe without registering. It doubles
-        # intent traffic, so it is off unless asked for.
-        self._intent_reemit_blanket = blanket
-
-    def _record_intent_alias(self, msg_type):
-        """Note that a handler subscribed to ``msg_type``.
-
-        Only per-intent dispatch topics are recorded; the registry ignores
-        everything else. A subscription written with the legacy ``.intent``
-        suffix is what marks the canonical intent as needing the mirror.
-        """
-        if self._intent_aliases is not None:
-            self._intent_aliases.register(msg_type)
-
-    def _forget_intent_alias(self, msg_type):
-        """Drop the alias of ``msg_type`` once nothing listens on it."""
-        if self._intent_aliases is None:
+    def _bridge_intent_topics(self, message):
+        """Fire the counterpart spelling of an intent dispatch, if any."""
+        if not self._translator.emit_legacy:
             return
-        alias = self._intent_aliases.legacy_alias(msg_type)
-        if alias is None:
+        if not is_intent_topic(message.msg_type):
             return
-        if not self.ee.listeners(alias):
-            self._intent_aliases.deregister(msg_type)
-
-    def _reemit_legacy_intent(self, message):
-        """Dispatch the suffixed twin of ``message``, if one is called for.
-
-        The twin carries the same data and context plus
-        :data:`INTENT_REEMIT_CONTEXT_KEY`, and fires at most once: it is
-        already the suffixed spelling, which ``legacy_reemit_targets`` never
-        mirrors again.
-        """
-        if self._intent_aliases is None or not self._translator.emit_legacy:
-            return
-        if message.context.get(INTENT_REEMIT_CONTEXT_KEY):
-            return
-        for topic in legacy_reemit_targets(message.msg_type,
-                                           registry=self._intent_aliases,
-                                           blanket=self._intent_reemit_blanket):
-            twin = message.forward(topic, message.data)
-            twin.context[INTENT_REEMIT_CONTEXT_KEY] = True
-            self.ee.emit(topic, twin)
+        canonical = canonical_intent_topic(message.msg_type)
+        if canonical == message.msg_type:
+            twin = message.forward(legacy_intent_topic(message.msg_type),
+                                   message.data)
+            twin.context[INTENT_COMPAT_TWIN_KEY] = True
+            self.ee.emit(twin.msg_type, twin)
+        elif not message.context.get(INTENT_COMPAT_TWIN_KEY):
+            self.ee.emit(canonical, message.forward(canonical, message.data))
 
 
 class FakeBus(_LegacyIntentBridge):
@@ -161,8 +122,6 @@ class FakeBus(_LegacyIntentBridge):
         self._translator = _resolve_bus_flags(kwargs)
         self._handler_guards = {}        # handler -> shared mirror-guard
         self._dedup_registrations = {}   # handler -> [(msg_type, wrapped), ...]
-        # legacy intent-topic bridge, gated by the SAME emit_legacy flag
-        self._init_intent_bridge(kwargs)
         self.on_open()
         try:
             self.session_id = kwargs["session"].session_id
@@ -173,7 +132,6 @@ class FakeBus(_LegacyIntentBridge):
                 self.on_default_session_update)
 
     def on(self, msg_type, handler):
-        self._record_intent_alias(msg_type)
         # wrap handlers on migrated topics so a handler subscribed to both the
         # legacy and ovos.* topic fires once (the mirror is dropped)
         if self._translator.is_migrated(msg_type):
@@ -193,7 +151,6 @@ class FakeBus(_LegacyIntentBridge):
         self.ee.on(msg_type, handler)
 
     def once(self, msg_type, handler):
-        self._record_intent_alias(msg_type)
         self.ee.once(msg_type, handler)
 
     def emit(self, message):
@@ -235,9 +192,9 @@ class FakeBus(_LegacyIntentBridge):
                 self.ee.emit(topic, message.forward(topic, translated))
             except Exception as e:
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
-        # legacy intent-topic bridge: mirror an intent dispatch onto its
-        # ``.intent``-suffixed twin for handlers written against old workshop.
-        self._reemit_legacy_intent(message)
+        # legacy intent-topic bridge: fire the counterpart spelling of an
+        # intent dispatch, for handlers written against old workshop.
+        self._bridge_intent_topics(message)
 
     def on_message(self, *args):
         """
@@ -337,17 +294,14 @@ class FakeBus(_LegacyIntentBridge):
             if not regs:
                 self._dedup_registrations.pop(handler, None)
                 self._handler_guards.pop(handler, None)
-            self._forget_intent_alias(msg_type)
             return
         try:
             self.ee.remove_listener(msg_type, handler)
         except Exception:
             pass
-        self._forget_intent_alias(msg_type)
 
     def remove_all_listeners(self, event_name):
         self.ee.remove_all_listeners(event_name)
-        self._forget_intent_alias(event_name)
 
     def create_client(self):
         return self
@@ -486,8 +440,6 @@ class AsyncFakeBus(_LegacyIntentBridge):
         self._translator = _resolve_bus_flags(kwargs)
         self._handler_guards = {}        # handler -> shared mirror-guard
         self._dedup_registrations = {}   # handler -> [(msg_type, wrapped), ...]
-        # legacy intent-topic bridge, gated by the SAME emit_legacy flag
-        self._init_intent_bridge(kwargs)
         self.connected_event = asyncio.Event()
         self.connected_event.set()
         self.on_open()
@@ -504,7 +456,6 @@ class AsyncFakeBus(_LegacyIntentBridge):
     # ------------------------------------------------------------------
 
     def on(self, msg_type, handler):
-        self._record_intent_alias(msg_type)
         # wrap handlers on migrated topics so a handler subscribed to both the
         # legacy and ovos.* topic fires once (the mirror is dropped) -- same as
         # FakeBus.on / MessageBusClient.on.
@@ -525,7 +476,6 @@ class AsyncFakeBus(_LegacyIntentBridge):
         self.ee.on(msg_type, handler)
 
     def once(self, msg_type, handler):
-        self._record_intent_alias(msg_type)
         self.ee.once(msg_type, handler)
 
     def remove(self, msg_type, handler):
@@ -540,17 +490,14 @@ class AsyncFakeBus(_LegacyIntentBridge):
             if not regs:
                 self._dedup_registrations.pop(handler, None)
                 self._handler_guards.pop(handler, None)
-            self._forget_intent_alias(msg_type)
             return
         try:
             self.ee.remove_listener(msg_type, handler)
         except Exception:
             pass
-        self._forget_intent_alias(msg_type)
 
     def remove_all_listeners(self, event_name):
         self.ee.remove_all_listeners(event_name)
-        self._forget_intent_alias(event_name)
 
     # ------------------------------------------------------------------
     # Lifecycle (async)
@@ -601,9 +548,9 @@ class AsyncFakeBus(_LegacyIntentBridge):
                 self.ee.emit(topic, message.forward(topic, translated))
             except Exception as e:
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
-        # legacy intent-topic bridge: mirror an intent dispatch onto its
-        # ``.intent``-suffixed twin for handlers written against old workshop.
-        self._reemit_legacy_intent(message)
+        # legacy intent-topic bridge: fire the counterpart spelling of an
+        # intent dispatch, for handlers written against old workshop.
+        self._bridge_intent_topics(message)
 
     # ------------------------------------------------------------------
     # Sync helpers used internally — same as FakeBus

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -216,7 +216,10 @@ class FakeBus(_LegacyIntentBridge):
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
         # legacy intent-topic bridge: fire the counterpart spelling of an
         # intent dispatch, for handlers written against old workshop.
-        self._bridge_intent_topics(message, is_intent_twin)
+        try:
+            self._bridge_intent_topics(message, is_intent_twin)
+        except Exception as e:
+            LOG.exception(f"Error in intent-topic bridge for '{message.msg_type}': {e}")
 
     def on_message(self, *args):
         """
@@ -576,7 +579,10 @@ class AsyncFakeBus(_LegacyIntentBridge):
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
         # legacy intent-topic bridge: fire the counterpart spelling of an
         # intent dispatch, for handlers written against old workshop.
-        self._bridge_intent_topics(message, is_intent_twin)
+        try:
+            self._bridge_intent_topics(message, is_intent_twin)
+        except Exception as e:
+            LOG.exception(f"Error in intent-topic bridge for '{message.msg_type}': {e}")
 
     # ------------------------------------------------------------------
     # Sync helpers used internally — same as FakeBus

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -57,7 +57,98 @@ def _resolve_bus_flags(kwargs):
     return NamespaceTranslator(modernize=modernize, emit_legacy=emit_legacy)
 
 
-class FakeBus:
+# --- legacy intent-topic compat (non-normative migration tooling) ----------
+#
+# Old ovos-workshop releases built the per-intent dispatch topic from the
+# padatious resource FILENAME, so the ``.intent`` extension leaked onto the
+# wire: a skill with ``food.order.intent`` listened on
+# ``<skill_id>:food.order.intent``. Current workshop is spec-pure and
+# registers the canonical ``<skill_id>:food.order`` (OVOS-MSG-1 §2.1.1).
+#
+# ``ovos_spec_tools.intent_topics`` is the whole compat surface for that gap.
+# It is newer than the spec-tools floor declared here, so the import is
+# guarded: against an older spec-tools the fake bus behaves as before.
+try:
+    from ovos_spec_tools.intent_topics import (IntentAliasRegistry,
+                                               legacy_reemit_targets)
+    _HAS_INTENT_TOPICS = True
+except ImportError:  # spec-tools without OVOS-INTENT-4 compat helpers
+    IntentAliasRegistry = None
+    legacy_reemit_targets = None
+    _HAS_INTENT_TOPICS = False
+
+#: Context flag stamped on a mirrored intent dispatch. A message carrying it is
+#: already a twin, so it is never mirrored again. Same key the real
+#: ``MessageBusClient`` uses.
+INTENT_REEMIT_CONTEXT_KEY = "__legacy_intent_reemit__"
+
+
+class _LegacyIntentBridge:
+    """Mirror an intent dispatch onto its legacy ``.intent``-suffixed twin.
+
+    Shared by :class:`FakeBus` and :class:`AsyncFakeBus` so both test doubles
+    behave like ``ovos_bus_client.MessageBusClient``, which runs the same
+    bridge next to its namespace bridge. A test double that skipped it would
+    hide the compat path from every harness built on it.
+
+    The alias table is owned by the bus instance and filled from its own
+    ``on()`` / ``once()`` calls: a bus mirrors only the intents one of its own
+    handlers asked for by the suffixed name, so no topic nobody listens on is
+    invented.
+    """
+
+    def _init_intent_bridge(self, kwargs):
+        self._intent_aliases = IntentAliasRegistry() if _HAS_INTENT_TOPICS else None
+        blanket = kwargs.get("intent_reemit_blanket", _UNSET)
+        if blanket is _UNSET:
+            blanket = _bus_flag("OVOS_BUS_INTENT_REEMIT_BLANKET",
+                                "intent_reemit_blanket", default=False)
+        # blanket mode mirrors EVERY intent dispatch, registered alias or not,
+        # for pure-bus listeners that subscribe without registering. It doubles
+        # intent traffic, so it is off unless asked for.
+        self._intent_reemit_blanket = blanket
+
+    def _record_intent_alias(self, msg_type):
+        """Note that a handler subscribed to ``msg_type``.
+
+        Only per-intent dispatch topics are recorded; the registry ignores
+        everything else. A subscription written with the legacy ``.intent``
+        suffix is what marks the canonical intent as needing the mirror.
+        """
+        if self._intent_aliases is not None:
+            self._intent_aliases.register(msg_type)
+
+    def _forget_intent_alias(self, msg_type):
+        """Drop the alias of ``msg_type`` once nothing listens on it."""
+        if self._intent_aliases is None:
+            return
+        alias = self._intent_aliases.legacy_alias(msg_type)
+        if alias is None:
+            return
+        if not self.ee.listeners(alias):
+            self._intent_aliases.deregister(msg_type)
+
+    def _reemit_legacy_intent(self, message):
+        """Dispatch the suffixed twin of ``message``, if one is called for.
+
+        The twin carries the same data and context plus
+        :data:`INTENT_REEMIT_CONTEXT_KEY`, and fires at most once: it is
+        already the suffixed spelling, which ``legacy_reemit_targets`` never
+        mirrors again.
+        """
+        if self._intent_aliases is None or not self._translator.emit_legacy:
+            return
+        if message.context.get(INTENT_REEMIT_CONTEXT_KEY):
+            return
+        for topic in legacy_reemit_targets(message.msg_type,
+                                           registry=self._intent_aliases,
+                                           blanket=self._intent_reemit_blanket):
+            twin = message.forward(topic, message.data)
+            twin.context[INTENT_REEMIT_CONTEXT_KEY] = True
+            self.ee.emit(topic, twin)
+
+
+class FakeBus(_LegacyIntentBridge):
     def __init__(self, *args, **kwargs):
         self.started_running = False
         self.session_id = "default"
@@ -70,6 +161,8 @@ class FakeBus:
         self._translator = _resolve_bus_flags(kwargs)
         self._handler_guards = {}        # handler -> shared mirror-guard
         self._dedup_registrations = {}   # handler -> [(msg_type, wrapped), ...]
+        # legacy intent-topic bridge, gated by the SAME emit_legacy flag
+        self._init_intent_bridge(kwargs)
         self.on_open()
         try:
             self.session_id = kwargs["session"].session_id
@@ -80,6 +173,7 @@ class FakeBus:
                 self.on_default_session_update)
 
     def on(self, msg_type, handler):
+        self._record_intent_alias(msg_type)
         # wrap handlers on migrated topics so a handler subscribed to both the
         # legacy and ovos.* topic fires once (the mirror is dropped)
         if self._translator.is_migrated(msg_type):
@@ -99,6 +193,7 @@ class FakeBus:
         self.ee.on(msg_type, handler)
 
     def once(self, msg_type, handler):
+        self._record_intent_alias(msg_type)
         self.ee.once(msg_type, handler)
 
     def emit(self, message):
@@ -140,6 +235,9 @@ class FakeBus:
                 self.ee.emit(topic, message.forward(topic, translated))
             except Exception as e:
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
+        # legacy intent-topic bridge: mirror an intent dispatch onto its
+        # ``.intent``-suffixed twin for handlers written against old workshop.
+        self._reemit_legacy_intent(message)
 
     def on_message(self, *args):
         """
@@ -239,14 +337,17 @@ class FakeBus:
             if not regs:
                 self._dedup_registrations.pop(handler, None)
                 self._handler_guards.pop(handler, None)
+            self._forget_intent_alias(msg_type)
             return
         try:
             self.ee.remove_listener(msg_type, handler)
         except Exception:
             pass
+        self._forget_intent_alias(msg_type)
 
     def remove_all_listeners(self, event_name):
         self.ee.remove_all_listeners(event_name)
+        self._forget_intent_alias(event_name)
 
     def create_client(self):
         return self
@@ -357,7 +458,7 @@ class Message(FakeMessage):
         return FakeMessage(*args, **kwargs)
 
 
-class AsyncFakeBus:
+class AsyncFakeBus(_LegacyIntentBridge):
     """In-process stand-in for ``AsyncMessageBusClient``.
 
     Mirrors the same surface as the real async bus client: ``connect`` /
@@ -385,6 +486,8 @@ class AsyncFakeBus:
         self._translator = _resolve_bus_flags(kwargs)
         self._handler_guards = {}        # handler -> shared mirror-guard
         self._dedup_registrations = {}   # handler -> [(msg_type, wrapped), ...]
+        # legacy intent-topic bridge, gated by the SAME emit_legacy flag
+        self._init_intent_bridge(kwargs)
         self.connected_event = asyncio.Event()
         self.connected_event.set()
         self.on_open()
@@ -401,6 +504,7 @@ class AsyncFakeBus:
     # ------------------------------------------------------------------
 
     def on(self, msg_type, handler):
+        self._record_intent_alias(msg_type)
         # wrap handlers on migrated topics so a handler subscribed to both the
         # legacy and ovos.* topic fires once (the mirror is dropped) -- same as
         # FakeBus.on / MessageBusClient.on.
@@ -421,6 +525,7 @@ class AsyncFakeBus:
         self.ee.on(msg_type, handler)
 
     def once(self, msg_type, handler):
+        self._record_intent_alias(msg_type)
         self.ee.once(msg_type, handler)
 
     def remove(self, msg_type, handler):
@@ -435,14 +540,17 @@ class AsyncFakeBus:
             if not regs:
                 self._dedup_registrations.pop(handler, None)
                 self._handler_guards.pop(handler, None)
+            self._forget_intent_alias(msg_type)
             return
         try:
             self.ee.remove_listener(msg_type, handler)
         except Exception:
             pass
+        self._forget_intent_alias(msg_type)
 
     def remove_all_listeners(self, event_name):
         self.ee.remove_all_listeners(event_name)
+        self._forget_intent_alias(event_name)
 
     # ------------------------------------------------------------------
     # Lifecycle (async)
@@ -493,6 +601,9 @@ class AsyncFakeBus:
                 self.ee.emit(topic, message.forward(topic, translated))
             except Exception as e:
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
+        # legacy intent-topic bridge: mirror an intent dispatch onto its
+        # ``.intent``-suffixed twin for handlers written against old workshop.
+        self._reemit_legacy_intent(message)
 
     # ------------------------------------------------------------------
     # Sync helpers used internally — same as FakeBus

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -93,19 +93,35 @@ class _LegacyIntentBridge:
     reaches each handler exactly once. Nothing tracks who listens to what.
     """
 
-    def _bridge_intent_topics(self, message):
-        """Fire the counterpart spelling of an intent dispatch, if any."""
+    def _bridge_intent_topics(self, message, is_twin=False):
+        """Fire the counterpart spelling of an intent dispatch, if any.
+
+        ``is_twin`` is the twin-marker decision made by the caller, which pops
+        :data:`INTENT_COMPAT_TWIN_KEY` off the message context BEFORE local
+        dispatch so it cannot ride onto descendants. The marker is therefore
+        never read from ``context`` here — only ``is_twin`` is trusted.
+        ``Message.forward()``/``reply()`` deep-copy the whole context, so a
+        marked frame that stayed marked would brand every follow-up message a
+        twin and silently suppress its modernization.
+        """
         if not self._translator.emit_legacy:
             return
         if not is_intent_topic(message.msg_type):
             return
         canonical = canonical_intent_topic(message.msg_type)
         if canonical == message.msg_type:
-            twin = message.forward(legacy_intent_topic(message.msg_type),
-                                   message.data)
-            twin.context[INTENT_COMPAT_TWIN_KEY] = True
-            self.ee.emit(twin.msg_type, twin)
-        elif not message.context.get(INTENT_COMPAT_TWIN_KEY):
+            # RULE 1. The twin is an outbound wire frame: it carries the marker
+            # on the wire (a receiver in another process needs it to skip
+            # re-modernizing), so its serialized form goes on the "message"
+            # firehose marked. What reaches LOCAL handlers is an UNMARKED copy,
+            # mirroring the real client, whose local delivery happens on the
+            # receive side after the marker is popped — descendants stay clean.
+            legacy = legacy_intent_topic(message.msg_type)
+            wire_twin = message.forward(legacy, message.data)
+            wire_twin.context[INTENT_COMPAT_TWIN_KEY] = True
+            self.ee.emit("message", wire_twin.serialize())
+            self.ee.emit(legacy, message.forward(legacy, message.data))
+        elif not is_twin:
             self.ee.emit(canonical, message.forward(canonical, message.data))
 
 
@@ -174,6 +190,12 @@ class FakeBus(_LegacyIntentBridge):
         # run.
         self.on_message(message.serialize())
         self.ee.emit("message", message.serialize())
+        # RULE 2 dedup marker: read it, then POP it before any local dispatch.
+        # The "message" firehose above still carries the marked frame (wire
+        # survival), but local topic handlers and their forward()/reply()
+        # descendants must start clean, or an unrelated suffixed intent emitted
+        # from a handler would inherit the marker and never be modernized.
+        is_intent_twin = message.context.pop(INTENT_COMPAT_TWIN_KEY, False)
         try:
             self.ee.emit(message.msg_type, message)
         except Exception as e:
@@ -194,7 +216,7 @@ class FakeBus(_LegacyIntentBridge):
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
         # legacy intent-topic bridge: fire the counterpart spelling of an
         # intent dispatch, for handlers written against old workshop.
-        self._bridge_intent_topics(message)
+        self._bridge_intent_topics(message, is_intent_twin)
 
     def on_message(self, *args):
         """
@@ -534,6 +556,10 @@ class AsyncFakeBus(_LegacyIntentBridge):
         # session mutations with the stale emit-time snapshot).
         self.on_message(message.serialize())
         self.ee.emit("message", message.serialize())
+        # RULE 2 dedup marker: pop it before local dispatch — see FakeBus.emit.
+        # The firehose above keeps the marked frame (wire survival); local
+        # handlers and their forward()/reply() descendants start clean.
+        is_intent_twin = message.context.pop(INTENT_COMPAT_TWIN_KEY, False)
         try:
             self.ee.emit(message.msg_type, message)
         except Exception as e:
@@ -550,7 +576,7 @@ class AsyncFakeBus(_LegacyIntentBridge):
                 LOG.exception(f"Error in counterpart dispatch for '{topic}': {e}")
         # legacy intent-topic bridge: fire the counterpart spelling of an
         # intent dispatch, for handlers written against old workshop.
-        self._bridge_intent_topics(message)
+        self._bridge_intent_topics(message, is_intent_twin)
 
     # ------------------------------------------------------------------
     # Sync helpers used internally — same as FakeBus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.6.0a1",  # intent_topics helpers for the FakeBus legacy re-emit
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
-    "ovos-spec-tools>=1.6.0a1",  # intent_topics helpers for the FakeBus legacy re-emit
+    "ovos-spec-tools>=1.6.0a2",  # intent_topics helpers for the FakeBus legacy re-emit
 ]
 
 [project.urls]

--- a/test/unittests/log_test/configured.log
+++ b/test/unittests/log_test/configured.log
@@ -1,126 +1,96 @@
-2026-03-11 04:12:11.787 - configured - ovos_utils.network_utils:get_external_ip:78 - ERROR - Got resp=503: 
-2026-03-11 04:12:11.789 - configured - ovos_utils.network_utils:get_external_ip:80 - ERROR - Unable to get external IP Address: network error
-2026-03-11 04:12:11.796 - configured - ovos_utils.network_utils:check_captive_portal:162 - ERROR - Error checking for captive portal
-Traceback (most recent call last):
-  File "/home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/ovos_utils/network_utils.py", line 156, in check_captive_portal
-    html_doc = requests.get(host).text
-               ~~~~~~~~~~~~^^^^^^
-  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1169, in __call__
-    return self._mock_call(*args, **kwargs)
-           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
-  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1173, in _mock_call
-    return self._execute_mock_call(*args, **kwargs)
-           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
-  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1228, in _execute_mock_call
-    raise effect
-Exception: timeout
-2026-03-11 04:12:11.823 - configured - ovos_utils.ocp:from_dict:254 - ERROR - track dictionary does not contain 'uri', it is not a valid MediaEntry
-2026-03-11 04:12:11.824 - configured - ovos_utils.ocp:from_dict:256 - WARNING - DEPRECATED: use dict2entry() for Playlists and PluginStreams, MediaEntry.from_dict is only for regular media, will start throwing ValueError in 0.1.0
-2026-03-11 04:12:11.837 - configured - ovos_utils.ocp:available_extractors:165 - ERROR - please install/update ovos_plugin_manager
-2026-03-11 04:12:11.841 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
-2026-03-11 04:12:11.842 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
-2026-03-11 04:12:11.842 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
-2026-03-11 04:12:11.843 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='http://missing.com/x.mp3', title='', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
-2026-03-11 04:12:11.852 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 2
-2026-03-11 04:12:11.853 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
-2026-03-11 04:12:11.854 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='nonexistent', title='nonexistent', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
-2026-03-11 04:12:11.857 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (3! Going to start of playlist
-2026-03-11 04:12:11.858 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
-2026-03-11 04:12:11.859 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
-2026-03-11 04:12:11.860 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (100! Going to start of playlist
-2026-03-11 04:12:11.877 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (0! Going to start of playlist
-2026-03-11 04:12:11.878 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
-2026-03-11 04:12:11.878 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
-2026-03-11 04:12:11.879 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
-2026-03-11 04:12:11.880 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (10! Going to start of playlist
-2026-03-11 04:12:11.882 - configured - ovos_utils.parse:_validate_matching_strategy:27 - ERROR - rapidfuzz is not installed, falling back to SequenceMatcher for all match strategies
-2026-03-11 04:12:11.882 - configured - ovos_utils.parse:_validate_matching_strategy:29 - WARNING - pip install rapidfuzz
-2026-03-11 04:12:11.904 - configured - ovos_utils.security:decrypt:93 - ERROR - run pip install pycryptodomex
-2026-03-11 04:12:11.906 - configured - ovos_utils.security:decrypt:103 - ERROR - decryption failed, invalid key?
-2026-03-11 04:12:11.910 - configured - ovos_utils.security:encrypt:80 - ERROR - run pip install pycryptodomex
-2026-03-11 04:12:11.912 - configured - ovos_utils.security:create_self_signed_cert:34 - ERROR - run pip install pyopenssl
-2026-03-11 04:12:11.917 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.918 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'my_service'
-2026-03-11 04:12:11.918 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.919 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.920 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.921 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.923 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.924 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.924 - configured - ovos_utils.skill_installer:handle_install_python:391 - ERROR - pip disabled in mycroft.conf
-2026-03-11 04:12:11.925 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.926 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.927 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.928 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.929 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.931 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.932 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.932 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.933 - configured - ovos_utils.skill_installer:handle_uninstall_python:427 - ERROR - pip disabled in mycroft.conf
-2026-03-11 04:12:11.934 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.934 - configured - ovos_utils.skill_installer:pip_install:230 - ERROR - no package list provided to install
-2026-03-11 04:12:11.935 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.937 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.938 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
-2026-03-11 04:12:11.938 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://example.com/c.txt my-pkg
-2026-03-11 04:12:11.939 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.940 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
-2026-03-11 04:12:11.940 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/.venv/bin/python3 -m pip install -c http://example.com/c.txt my-pkg
-2026-03-11 04:12:11.941 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.942 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing bad-pkg
-2026-03-11 04:12:11.943 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-stable.txt bad-pkg
-2026-03-11 04:12:11.944 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.945 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing pkg
-2026-03-11 04:12:11.945 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.947 - configured - ovos_utils.skill_installer:validate_constraints:205 - ERROR - Couldn't find the constraints file
-2026-03-11 04:12:11.948 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
-2026-03-11 04:12:11.949 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/missing.txt
-2026-03-11 04:12:11.949 - configured - ovos_utils.skill_installer:validate_constraints:195 - ERROR - Remote constraints file not accessible: 404
-2026-03-11 04:12:11.950 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
-2026-03-11 04:12:11.951 - configured - ovos_utils.skill_installer:validate_constraints:201 - ERROR - Error accessing remote constraints: timeout
-2026-03-11 04:12:11.952 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.953 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.954 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.954 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.955 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.956 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.956 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.957 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt --break-system-packages pkg
-2026-03-11 04:12:11.958 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.959 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.959 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt --pre pkg
-2026-03-11 04:12:11.960 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.961 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.961 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.962 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.963 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.963 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.964 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.965 - configured - ovos_utils.skill_installer:pip_uninstall:295 - ERROR - no package list provided to uninstall
-2026-03-11 04:12:11.966 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.967 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:12.298 - configured - ovos_utils.skill_installer:pip_uninstall:330 - ERROR - tried to uninstall a protected package: ['ovos-core']
-2026-03-11 04:12:12.299 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:12.461 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:12.462 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:12.464 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:12.925 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:12.926 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/.venv/bin/python3 -m pip uninstall -y custom-pkg
-2026-03-11 04:12:12.929 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.262 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.263 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.267 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.269 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.294 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.296 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.296 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.297 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.298 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.569 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.570 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y --break-system-packages custom-pkg
-2026-03-11 04:12:13.571 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.859 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.859 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.913 - configured - ovos_utils.system:system_reboot:83 - DEBUG - sudo systemctl reboot -i
-2026-03-11 04:12:13.915 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - sudo systemctl poweroff -i
-2026-03-11 04:12:13.916 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - systemctl poweroff -i
+2026-08-01 01:07:01.284 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - systemctl poweroff -i
+2026-08-01 01:07:01.296 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - sudo systemctl poweroff -i
+2026-08-01 01:07:01.308 - configured - ovos_utils.system:system_reboot:83 - DEBUG - sudo systemctl reboot -i
+2026-08-01 01:07:01.423 - configured - ovos_utils.security:decrypt:105 - ERROR - run pip install pycryptodomex
+2026-08-01 01:07:01.434 - configured - ovos_utils.security:encrypt:92 - ERROR - run pip install pycryptodomex
+2026-08-01 01:07:01.444 - configured - ovos_utils.security:decrypt:115 - ERROR - decryption failed, invalid key?
+2026-08-01 01:07:01.463 - configured - ovos_utils.security:create_self_signed_cert:46 - ERROR - run pip install pyopenssl
+2026-08-01 01:07:11.840 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:11.847 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:11.855 - configured - ovos_utils.skill_installer:handle_install_python:391 - ERROR - pip disabled in mycroft.conf
+2026-08-01 01:07:11.862 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:11.871 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:11.878 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:11.885 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:11.892 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:11.900 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:11.908 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:11.918 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
+2026-08-01 01:07:11.925 - configured - ovos_utils.skill_installer:validate_constraints:205 - ERROR - Couldn't find the constraints file
+2026-08-01 01:07:11.931 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
+2026-08-01 01:07:11.936 - configured - ovos_utils.skill_installer:validate_constraints:201 - ERROR - Error accessing remote constraints: timeout
+2026-08-01 01:07:11.943 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/missing.txt
+2026-08-01 01:07:11.948 - configured - ovos_utils.skill_installer:validate_constraints:195 - ERROR - Remote constraints file not accessible: 404
+2026-08-01 01:07:11.955 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:12.220 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 01:07:12.226 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.venvs/ovos/bin/python -m pip uninstall -y custom-pkg
+2026-08-01 01:07:12.232 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.238 - configured - ovos_utils.skill_installer:pip_uninstall:295 - ERROR - no package list provided to uninstall
+2026-08-01 01:07:12.246 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.254 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:12.490 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 01:07:12.495 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y --break-system-packages custom-pkg
+2026-08-01 01:07:12.502 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:12.508 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 01:07:12.513 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 01:07:12.520 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:12.591 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 01:07:12.596 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 01:07:12.604 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:12.667 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 01:07:12.673 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 01:07:12.683 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.764 - configured - ovos_utils.skill_installer:pip_uninstall:330 - ERROR - tried to uninstall a protected package: ['ovos-core']
+2026-08-01 01:07:12.779 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:12.788 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 01:07:12.795 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 01:07:12.803 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:12.874 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 01:07:12.880 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 01:07:12.889 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.896 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing pkg
+2026-08-01 01:07:12.903 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 01:07:12.912 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.919 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing bad-pkg
+2026-08-01 01:07:12.924 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-stable.txt bad-pkg
+2026-08-01 01:07:12.934 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.943 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.950 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
+2026-08-01 01:07:12.957 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://example.com/c.txt my-pkg
+2026-08-01 01:07:12.966 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.973 - configured - ovos_utils.skill_installer:pip_install:230 - ERROR - no package list provided to install
+2026-08-01 01:07:12.984 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:12.990 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
+2026-08-01 01:07:12.995 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.venvs/ovos/bin/python -m pip install -c http://example.com/c.txt my-pkg
+2026-08-01 01:07:13.005 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:13.024 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:13.036 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.043 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 01:07:13.049 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 01:07:13.056 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:13.065 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:13.074 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.078 - configured - ovos_utils.skill_installer:handle_uninstall_python:427 - ERROR - pip disabled in mycroft.conf
+2026-08-01 01:07:13.087 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 01:07:13.095 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'my_service'
+2026-08-01 01:07:13.102 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.109 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.116 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.122 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 01:07:13.127 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 01:07:13.135 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.140 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 01:07:13.146 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt --pre pkg
+2026-08-01 01:07:13.154 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.159 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 01:07:13.164 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt --break-system-packages pkg
+2026-08-01 01:07:13.171 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 01:07:13.176 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 01:07:13.181 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 01:07:13.194 - configured - ovos_utils.events:add:165 - DEBUG - Added event: id:f
+2026-08-01 01:07:13.205 - configured - ovos_utils.events:remove:173 - DEBUG - Removing event id:f
+2026-08-01 01:07:13.347 - configured - ovos_utils.gui:get_ui_directories:90 - DEBUG - Skill supports GUI framework: qt5 from folder: /home/miro/tmp/tmpilwf5jno/gui/qt5
+2026-08-01 01:07:13.352 - configured - ovos_utils.gui:get_ui_directories:90 - DEBUG - Skill supports GUI framework: kivy from folder: /home/miro/tmp/tmpilwf5jno/gui/kivy
+2026-08-01 01:07:13.360 - configured - ovos_utils.gui:get_ui_directories:85 - DEBUG - legacy UI directory found - Handling `ui` directory as `qt5`
+2026-08-01 01:07:13.421 - configured - ovos_utils.parse:_validate_matching_strategy:27 - ERROR - rapidfuzz is not installed, falling back to SequenceMatcher for all match strategies
+2026-08-01 01:07:13.426 - configured - ovos_utils.parse:_validate_matching_strategy:29 - WARNING - pip install rapidfuzz

--- a/test/unittests/log_test/configured.log
+++ b/test/unittests/log_test/configured.log
@@ -1,126 +1,126 @@
-2026-03-11 04:12:11.787 - configured - ovos_utils.network_utils:get_external_ip:78 - ERROR - Got resp=503: 
-2026-03-11 04:12:11.789 - configured - ovos_utils.network_utils:get_external_ip:80 - ERROR - Unable to get external IP Address: network error
-2026-03-11 04:12:11.796 - configured - ovos_utils.network_utils:check_captive_portal:162 - ERROR - Error checking for captive portal
+2026-08-01 19:07:55.198 - configured - ovos_utils.network_utils:get_external_ip:78 - ERROR - Got resp=503: 
+2026-08-01 19:07:55.202 - configured - ovos_utils.network_utils:get_external_ip:80 - ERROR - Unable to get external IP Address: network error
+2026-08-01 19:07:55.211 - configured - ovos_utils.network_utils:check_captive_portal:162 - ERROR - Error checking for captive portal
 Traceback (most recent call last):
-  File "/home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/ovos_utils/network_utils.py", line 156, in check_captive_portal
+  File "/home/miro/tmp/utils-fakebus-intent-reemit/ovos_utils/network_utils.py", line 156, in check_captive_portal
     html_doc = requests.get(host).text
-               ~~~~~~~~~~~~^^^^^^
-  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1169, in __call__
+               ^^^^^^^^^^^^^^^^^^
+  File "/home/miro/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/unittest/mock.py", line 1139, in __call__
     return self._mock_call(*args, **kwargs)
-           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
-  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1173, in _mock_call
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/miro/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/unittest/mock.py", line 1143, in _mock_call
     return self._execute_mock_call(*args, **kwargs)
-           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
-  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1228, in _execute_mock_call
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/miro/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/unittest/mock.py", line 1198, in _execute_mock_call
     raise effect
 Exception: timeout
-2026-03-11 04:12:11.823 - configured - ovos_utils.ocp:from_dict:254 - ERROR - track dictionary does not contain 'uri', it is not a valid MediaEntry
-2026-03-11 04:12:11.824 - configured - ovos_utils.ocp:from_dict:256 - WARNING - DEPRECATED: use dict2entry() for Playlists and PluginStreams, MediaEntry.from_dict is only for regular media, will start throwing ValueError in 0.1.0
-2026-03-11 04:12:11.837 - configured - ovos_utils.ocp:available_extractors:165 - ERROR - please install/update ovos_plugin_manager
-2026-03-11 04:12:11.841 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
-2026-03-11 04:12:11.842 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
-2026-03-11 04:12:11.842 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
-2026-03-11 04:12:11.843 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='http://missing.com/x.mp3', title='', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
-2026-03-11 04:12:11.852 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 2
-2026-03-11 04:12:11.853 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
-2026-03-11 04:12:11.854 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='nonexistent', title='nonexistent', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
-2026-03-11 04:12:11.857 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (3! Going to start of playlist
-2026-03-11 04:12:11.858 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
-2026-03-11 04:12:11.859 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
-2026-03-11 04:12:11.860 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (100! Going to start of playlist
-2026-03-11 04:12:11.877 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (0! Going to start of playlist
-2026-03-11 04:12:11.878 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
-2026-03-11 04:12:11.878 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
-2026-03-11 04:12:11.879 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
-2026-03-11 04:12:11.880 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (10! Going to start of playlist
-2026-03-11 04:12:11.882 - configured - ovos_utils.parse:_validate_matching_strategy:27 - ERROR - rapidfuzz is not installed, falling back to SequenceMatcher for all match strategies
-2026-03-11 04:12:11.882 - configured - ovos_utils.parse:_validate_matching_strategy:29 - WARNING - pip install rapidfuzz
-2026-03-11 04:12:11.904 - configured - ovos_utils.security:decrypt:93 - ERROR - run pip install pycryptodomex
-2026-03-11 04:12:11.906 - configured - ovos_utils.security:decrypt:103 - ERROR - decryption failed, invalid key?
-2026-03-11 04:12:11.910 - configured - ovos_utils.security:encrypt:80 - ERROR - run pip install pycryptodomex
-2026-03-11 04:12:11.912 - configured - ovos_utils.security:create_self_signed_cert:34 - ERROR - run pip install pyopenssl
-2026-03-11 04:12:11.917 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.918 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'my_service'
-2026-03-11 04:12:11.918 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.919 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.920 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.921 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.923 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.924 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.924 - configured - ovos_utils.skill_installer:handle_install_python:391 - ERROR - pip disabled in mycroft.conf
-2026-03-11 04:12:11.925 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.926 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.927 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.928 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.929 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.931 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.932 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.932 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.933 - configured - ovos_utils.skill_installer:handle_uninstall_python:427 - ERROR - pip disabled in mycroft.conf
-2026-03-11 04:12:11.934 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.934 - configured - ovos_utils.skill_installer:pip_install:230 - ERROR - no package list provided to install
-2026-03-11 04:12:11.935 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.937 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.938 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
-2026-03-11 04:12:11.938 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://example.com/c.txt my-pkg
-2026-03-11 04:12:11.939 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.940 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
-2026-03-11 04:12:11.940 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/.venv/bin/python3 -m pip install -c http://example.com/c.txt my-pkg
-2026-03-11 04:12:11.941 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.942 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing bad-pkg
-2026-03-11 04:12:11.943 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-stable.txt bad-pkg
-2026-03-11 04:12:11.944 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.945 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing pkg
-2026-03-11 04:12:11.945 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.947 - configured - ovos_utils.skill_installer:validate_constraints:205 - ERROR - Couldn't find the constraints file
-2026-03-11 04:12:11.948 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
-2026-03-11 04:12:11.949 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/missing.txt
-2026-03-11 04:12:11.949 - configured - ovos_utils.skill_installer:validate_constraints:195 - ERROR - Remote constraints file not accessible: 404
-2026-03-11 04:12:11.950 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
-2026-03-11 04:12:11.951 - configured - ovos_utils.skill_installer:validate_constraints:201 - ERROR - Error accessing remote constraints: timeout
-2026-03-11 04:12:11.952 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.953 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.954 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.954 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.955 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.956 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.956 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.957 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt --break-system-packages pkg
-2026-03-11 04:12:11.958 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.959 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.959 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt --pre pkg
-2026-03-11 04:12:11.960 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.961 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.961 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.962 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:11.963 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-03-11 04:12:11.963 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
-2026-03-11 04:12:11.964 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.965 - configured - ovos_utils.skill_installer:pip_uninstall:295 - ERROR - no package list provided to uninstall
-2026-03-11 04:12:11.966 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:11.967 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-03-11 04:12:12.298 - configured - ovos_utils.skill_installer:pip_uninstall:330 - ERROR - tried to uninstall a protected package: ['ovos-core']
-2026-03-11 04:12:12.299 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:12.461 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:12.462 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:12.464 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:12.925 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:12.926 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/.venv/bin/python3 -m pip uninstall -y custom-pkg
-2026-03-11 04:12:12.929 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.262 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.263 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.267 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.269 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.294 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.296 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.296 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.297 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.298 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.569 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.570 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y --break-system-packages custom-pkg
-2026-03-11 04:12:13.571 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-03-11 04:12:13.859 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-03-11 04:12:13.859 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
-2026-03-11 04:12:13.913 - configured - ovos_utils.system:system_reboot:83 - DEBUG - sudo systemctl reboot -i
-2026-03-11 04:12:13.915 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - sudo systemctl poweroff -i
-2026-03-11 04:12:13.916 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - systemctl poweroff -i
+2026-08-01 19:07:55.249 - configured - ovos_utils.ocp:from_dict:254 - ERROR - track dictionary does not contain 'uri', it is not a valid MediaEntry
+2026-08-01 19:07:55.251 - configured - ovos_utils.ocp:from_dict:256 - WARNING - DEPRECATED: use dict2entry() for Playlists and PluginStreams, MediaEntry.from_dict is only for regular media, will start throwing ValueError in 0.1.0
+2026-08-01 19:07:55.270 - configured - ovos_utils.ocp:available_extractors:165 - ERROR - please install/update ovos_plugin_manager
+2026-08-01 19:07:55.277 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
+2026-08-01 19:07:55.279 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
+2026-08-01 19:07:55.282 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
+2026-08-01 19:07:55.286 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='http://missing.com/x.mp3', title='', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
+2026-08-01 19:07:55.299 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 2
+2026-08-01 19:07:55.301 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
+2026-08-01 19:07:55.332 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='nonexistent', title='nonexistent', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
+2026-08-01 19:07:55.337 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (3! Going to start of playlist
+2026-08-01 19:07:55.340 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
+2026-08-01 19:07:55.343 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
+2026-08-01 19:07:55.345 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (100! Going to start of playlist
+2026-08-01 19:07:55.369 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (0! Going to start of playlist
+2026-08-01 19:07:55.371 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
+2026-08-01 19:07:55.373 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
+2026-08-01 19:07:55.375 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
+2026-08-01 19:07:55.378 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (10! Going to start of playlist
+2026-08-01 19:07:55.382 - configured - ovos_utils.parse:_validate_matching_strategy:27 - ERROR - rapidfuzz is not installed, falling back to SequenceMatcher for all match strategies
+2026-08-01 19:07:55.384 - configured - ovos_utils.parse:_validate_matching_strategy:29 - WARNING - pip install rapidfuzz
+2026-08-01 19:07:55.413 - configured - ovos_utils.security:decrypt:105 - ERROR - run pip install pycryptodomex
+2026-08-01 19:07:55.416 - configured - ovos_utils.security:decrypt:115 - ERROR - decryption failed, invalid key?
+2026-08-01 19:07:55.421 - configured - ovos_utils.security:encrypt:92 - ERROR - run pip install pycryptodomex
+2026-08-01 19:07:55.427 - configured - ovos_utils.security:create_self_signed_cert:46 - ERROR - run pip install pyopenssl
+2026-08-01 19:07:55.439 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.442 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'my_service'
+2026-08-01 19:07:55.444 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.447 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.450 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.452 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.455 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.458 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.460 - configured - ovos_utils.skill_installer:handle_install_python:391 - ERROR - pip disabled in mycroft.conf
+2026-08-01 19:07:55.463 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.466 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.468 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.472 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.475 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.478 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.481 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.483 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.486 - configured - ovos_utils.skill_installer:handle_uninstall_python:427 - ERROR - pip disabled in mycroft.conf
+2026-08-01 19:07:55.489 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.491 - configured - ovos_utils.skill_installer:pip_install:230 - ERROR - no package list provided to install
+2026-08-01 19:07:55.494 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.497 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.500 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
+2026-08-01 19:07:55.502 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://example.com/c.txt my-pkg
+2026-08-01 19:07:55.505 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.508 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
+2026-08-01 19:07:55.510 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.venvs/ovos/bin/python -m pip install -c http://example.com/c.txt my-pkg
+2026-08-01 19:07:55.513 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.516 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing bad-pkg
+2026-08-01 19:07:55.518 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-stable.txt bad-pkg
+2026-08-01 19:07:55.521 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.524 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing pkg
+2026-08-01 19:07:55.527 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 19:07:55.531 - configured - ovos_utils.skill_installer:validate_constraints:205 - ERROR - Couldn't find the constraints file
+2026-08-01 19:07:55.534 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
+2026-08-01 19:07:55.537 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/missing.txt
+2026-08-01 19:07:55.539 - configured - ovos_utils.skill_installer:validate_constraints:195 - ERROR - Remote constraints file not accessible: 404
+2026-08-01 19:07:55.542 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
+2026-08-01 19:07:55.545 - configured - ovos_utils.skill_installer:validate_constraints:201 - ERROR - Error accessing remote constraints: timeout
+2026-08-01 19:07:55.547 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.550 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.553 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.556 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 19:07:55.558 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 19:07:55.561 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.564 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 19:07:55.566 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt --break-system-packages pkg
+2026-08-01 19:07:55.569 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.572 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 19:07:55.574 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt --pre pkg
+2026-08-01 19:07:55.577 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.580 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 19:07:55.582 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 19:07:55.585 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.588 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-08-01 19:07:55.591 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
+2026-08-01 19:07:55.594 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.597 - configured - ovos_utils.skill_installer:pip_uninstall:295 - ERROR - no package list provided to uninstall
+2026-08-01 19:07:55.600 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.603 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-08-01 19:07:55.917 - configured - ovos_utils.skill_installer:pip_uninstall:330 - ERROR - tried to uninstall a protected package: ['ovos-core']
+2026-08-01 19:07:55.920 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:55.986 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 19:07:55.988 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 19:07:55.991 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:56.053 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 19:07:56.055 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.venvs/ovos/bin/python -m pip uninstall -y custom-pkg
+2026-08-01 19:07:56.058 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:56.121 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 19:07:56.123 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 19:07:56.127 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:56.130 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 19:07:56.132 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 19:07:56.135 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:56.138 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 19:07:56.140 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 19:07:56.144 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:56.206 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 19:07:56.208 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y --break-system-packages custom-pkg
+2026-08-01 19:07:56.211 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-08-01 19:07:56.278 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-08-01 19:07:56.280 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-08-01 19:07:56.368 - configured - ovos_utils.system:system_reboot:83 - DEBUG - sudo systemctl reboot -i
+2026-08-01 19:07:56.373 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - sudo systemctl poweroff -i
+2026-08-01 19:07:56.378 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - systemctl poweroff -i

--- a/test/unittests/log_test/configured.log
+++ b/test/unittests/log_test/configured.log
@@ -1,96 +1,126 @@
-2026-08-01 01:07:01.284 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - systemctl poweroff -i
-2026-08-01 01:07:01.296 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - sudo systemctl poweroff -i
-2026-08-01 01:07:01.308 - configured - ovos_utils.system:system_reboot:83 - DEBUG - sudo systemctl reboot -i
-2026-08-01 01:07:01.423 - configured - ovos_utils.security:decrypt:105 - ERROR - run pip install pycryptodomex
-2026-08-01 01:07:01.434 - configured - ovos_utils.security:encrypt:92 - ERROR - run pip install pycryptodomex
-2026-08-01 01:07:01.444 - configured - ovos_utils.security:decrypt:115 - ERROR - decryption failed, invalid key?
-2026-08-01 01:07:01.463 - configured - ovos_utils.security:create_self_signed_cert:46 - ERROR - run pip install pyopenssl
-2026-08-01 01:07:11.840 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:11.847 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:11.855 - configured - ovos_utils.skill_installer:handle_install_python:391 - ERROR - pip disabled in mycroft.conf
-2026-08-01 01:07:11.862 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:11.871 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:11.878 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:11.885 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:11.892 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:11.900 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:11.908 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:11.918 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
-2026-08-01 01:07:11.925 - configured - ovos_utils.skill_installer:validate_constraints:205 - ERROR - Couldn't find the constraints file
-2026-08-01 01:07:11.931 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
-2026-08-01 01:07:11.936 - configured - ovos_utils.skill_installer:validate_constraints:201 - ERROR - Error accessing remote constraints: timeout
-2026-08-01 01:07:11.943 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/missing.txt
-2026-08-01 01:07:11.948 - configured - ovos_utils.skill_installer:validate_constraints:195 - ERROR - Remote constraints file not accessible: 404
-2026-08-01 01:07:11.955 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:12.220 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-08-01 01:07:12.226 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.venvs/ovos/bin/python -m pip uninstall -y custom-pkg
-2026-08-01 01:07:12.232 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.238 - configured - ovos_utils.skill_installer:pip_uninstall:295 - ERROR - no package list provided to uninstall
-2026-08-01 01:07:12.246 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.254 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:12.490 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-08-01 01:07:12.495 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y --break-system-packages custom-pkg
-2026-08-01 01:07:12.502 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:12.508 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-08-01 01:07:12.513 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
-2026-08-01 01:07:12.520 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:12.591 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-08-01 01:07:12.596 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
-2026-08-01 01:07:12.604 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:12.667 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-08-01 01:07:12.673 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
-2026-08-01 01:07:12.683 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.764 - configured - ovos_utils.skill_installer:pip_uninstall:330 - ERROR - tried to uninstall a protected package: ['ovos-core']
-2026-08-01 01:07:12.779 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:12.788 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-08-01 01:07:12.795 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
-2026-08-01 01:07:12.803 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:12.874 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
-2026-08-01 01:07:12.880 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
-2026-08-01 01:07:12.889 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.896 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing pkg
-2026-08-01 01:07:12.903 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
-2026-08-01 01:07:12.912 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.919 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing bad-pkg
-2026-08-01 01:07:12.924 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-stable.txt bad-pkg
-2026-08-01 01:07:12.934 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.943 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.950 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
-2026-08-01 01:07:12.957 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://example.com/c.txt my-pkg
-2026-08-01 01:07:12.966 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.973 - configured - ovos_utils.skill_installer:pip_install:230 - ERROR - no package list provided to install
-2026-08-01 01:07:12.984 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:12.990 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
-2026-08-01 01:07:12.995 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.venvs/ovos/bin/python -m pip install -c http://example.com/c.txt my-pkg
-2026-08-01 01:07:13.005 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:13.024 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:13.036 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.043 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-08-01 01:07:13.049 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
-2026-08-01 01:07:13.056 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:13.065 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:13.074 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.078 - configured - ovos_utils.skill_installer:handle_uninstall_python:427 - ERROR - pip disabled in mycroft.conf
-2026-08-01 01:07:13.087 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
-2026-08-01 01:07:13.095 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'my_service'
-2026-08-01 01:07:13.102 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.109 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.116 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.122 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-08-01 01:07:13.127 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
-2026-08-01 01:07:13.135 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.140 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-08-01 01:07:13.146 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt --pre pkg
-2026-08-01 01:07:13.154 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.159 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-08-01 01:07:13.164 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt --break-system-packages pkg
-2026-08-01 01:07:13.171 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
-2026-08-01 01:07:13.176 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
-2026-08-01 01:07:13.181 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://x.com/c.txt pkg
-2026-08-01 01:07:13.194 - configured - ovos_utils.events:add:165 - DEBUG - Added event: id:f
-2026-08-01 01:07:13.205 - configured - ovos_utils.events:remove:173 - DEBUG - Removing event id:f
-2026-08-01 01:07:13.347 - configured - ovos_utils.gui:get_ui_directories:90 - DEBUG - Skill supports GUI framework: qt5 from folder: /home/miro/tmp/tmpilwf5jno/gui/qt5
-2026-08-01 01:07:13.352 - configured - ovos_utils.gui:get_ui_directories:90 - DEBUG - Skill supports GUI framework: kivy from folder: /home/miro/tmp/tmpilwf5jno/gui/kivy
-2026-08-01 01:07:13.360 - configured - ovos_utils.gui:get_ui_directories:85 - DEBUG - legacy UI directory found - Handling `ui` directory as `qt5`
-2026-08-01 01:07:13.421 - configured - ovos_utils.parse:_validate_matching_strategy:27 - ERROR - rapidfuzz is not installed, falling back to SequenceMatcher for all match strategies
-2026-08-01 01:07:13.426 - configured - ovos_utils.parse:_validate_matching_strategy:29 - WARNING - pip install rapidfuzz
+2026-03-11 04:12:11.787 - configured - ovos_utils.network_utils:get_external_ip:78 - ERROR - Got resp=503: 
+2026-03-11 04:12:11.789 - configured - ovos_utils.network_utils:get_external_ip:80 - ERROR - Unable to get external IP Address: network error
+2026-03-11 04:12:11.796 - configured - ovos_utils.network_utils:check_captive_portal:162 - ERROR - Error checking for captive portal
+Traceback (most recent call last):
+  File "/home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/ovos_utils/network_utils.py", line 156, in check_captive_portal
+    html_doc = requests.get(host).text
+               ~~~~~~~~~~~~^^^^^^
+  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1169, in __call__
+    return self._mock_call(*args, **kwargs)
+           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
+  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1173, in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
+  File "/home/miro/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/unittest/mock.py", line 1228, in _execute_mock_call
+    raise effect
+Exception: timeout
+2026-03-11 04:12:11.823 - configured - ovos_utils.ocp:from_dict:254 - ERROR - track dictionary does not contain 'uri', it is not a valid MediaEntry
+2026-03-11 04:12:11.824 - configured - ovos_utils.ocp:from_dict:256 - WARNING - DEPRECATED: use dict2entry() for Playlists and PluginStreams, MediaEntry.from_dict is only for regular media, will start throwing ValueError in 0.1.0
+2026-03-11 04:12:11.837 - configured - ovos_utils.ocp:available_extractors:165 - ERROR - please install/update ovos_plugin_manager
+2026-03-11 04:12:11.841 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
+2026-03-11 04:12:11.842 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
+2026-03-11 04:12:11.842 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 0
+2026-03-11 04:12:11.843 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='http://missing.com/x.mp3', title='', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
+2026-03-11 04:12:11.852 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 2
+2026-03-11 04:12:11.853 - configured - ovos_utils.ocp:goto_track:586 - DEBUG - New playlist position: 1
+2026-03-11 04:12:11.854 - configured - ovos_utils.ocp:goto_track:588 - ERROR - requested track not in the playlist: MediaEntry(uri='nonexistent', title='nonexistent', artist='', match_confidence=0, skill_id='ovos.common_play', playback=<PlaybackType.UNDEFINED: 100>, status=<TrackState.DISAMBIGUATION: 1>, media_type=<MediaType.GENERIC: 0>, length=0, image='', skill_icon='', javascript='')
+2026-03-11 04:12:11.857 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (3! Going to start of playlist
+2026-03-11 04:12:11.858 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
+2026-03-11 04:12:11.859 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
+2026-03-11 04:12:11.860 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (100! Going to start of playlist
+2026-03-11 04:12:11.877 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (0! Going to start of playlist
+2026-03-11 04:12:11.878 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (-1! Going to start of playlist
+2026-03-11 04:12:11.878 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
+2026-03-11 04:12:11.879 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (1! Going to start of playlist
+2026-03-11 04:12:11.880 - configured - ovos_utils.ocp:_validate_position:607 - ERROR - Playlist pointer is in an invalid position (10! Going to start of playlist
+2026-03-11 04:12:11.882 - configured - ovos_utils.parse:_validate_matching_strategy:27 - ERROR - rapidfuzz is not installed, falling back to SequenceMatcher for all match strategies
+2026-03-11 04:12:11.882 - configured - ovos_utils.parse:_validate_matching_strategy:29 - WARNING - pip install rapidfuzz
+2026-03-11 04:12:11.904 - configured - ovos_utils.security:decrypt:93 - ERROR - run pip install pycryptodomex
+2026-03-11 04:12:11.906 - configured - ovos_utils.security:decrypt:103 - ERROR - decryption failed, invalid key?
+2026-03-11 04:12:11.910 - configured - ovos_utils.security:encrypt:80 - ERROR - run pip install pycryptodomex
+2026-03-11 04:12:11.912 - configured - ovos_utils.security:create_self_signed_cert:34 - ERROR - run pip install pyopenssl
+2026-03-11 04:12:11.917 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.918 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'my_service'
+2026-03-11 04:12:11.918 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.919 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.920 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.921 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.923 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.924 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.924 - configured - ovos_utils.skill_installer:handle_install_python:391 - ERROR - pip disabled in mycroft.conf
+2026-03-11 04:12:11.925 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.926 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.927 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.928 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.929 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.931 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.932 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.932 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.933 - configured - ovos_utils.skill_installer:handle_uninstall_python:427 - ERROR - pip disabled in mycroft.conf
+2026-03-11 04:12:11.934 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.934 - configured - ovos_utils.skill_installer:pip_install:230 - ERROR - no package list provided to install
+2026-03-11 04:12:11.935 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.937 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.938 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
+2026-03-11 04:12:11.938 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /usr/bin/uv pip install -c http://example.com/c.txt my-pkg
+2026-03-11 04:12:11.939 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.940 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing my-pkg
+2026-03-11 04:12:11.940 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/.venv/bin/python3 -m pip install -c http://example.com/c.txt my-pkg
+2026-03-11 04:12:11.941 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.942 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing bad-pkg
+2026-03-11 04:12:11.943 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/refs/heads/main/constraints-stable.txt bad-pkg
+2026-03-11 04:12:11.944 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.945 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [ovos_test] (pip) Installing pkg
+2026-03-11 04:12:11.945 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
+2026-03-11 04:12:11.947 - configured - ovos_utils.skill_installer:validate_constraints:205 - ERROR - Couldn't find the constraints file
+2026-03-11 04:12:11.948 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
+2026-03-11 04:12:11.949 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/missing.txt
+2026-03-11 04:12:11.949 - configured - ovos_utils.skill_installer:validate_constraints:195 - ERROR - Remote constraints file not accessible: 404
+2026-03-11 04:12:11.950 - configured - ovos_utils.skill_installer:validate_constraints:191 - DEBUG - Constraints url: http://example.com/c.txt
+2026-03-11 04:12:11.951 - configured - ovos_utils.skill_installer:validate_constraints:201 - ERROR - Error accessing remote constraints: timeout
+2026-03-11 04:12:11.952 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.953 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.954 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.954 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-03-11 04:12:11.955 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
+2026-03-11 04:12:11.956 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.956 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-03-11 04:12:11.957 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt --break-system-packages pkg
+2026-03-11 04:12:11.958 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.959 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-03-11 04:12:11.959 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt --pre pkg
+2026-03-11 04:12:11.960 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.961 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-03-11 04:12:11.961 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
+2026-03-11 04:12:11.962 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:11.963 - configured - ovos_utils.skill_installer:pip_install:256 - INFO - [svc] (pip) Installing pkg
+2026-03-11 04:12:11.963 - configured - ovos_utils.skill_installer:pip_install:258 - DEBUG - /home/miro/.local/bin/uv pip install -c http://x.com/c.txt pkg
+2026-03-11 04:12:11.964 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.965 - configured - ovos_utils.skill_installer:pip_uninstall:295 - ERROR - no package list provided to uninstall
+2026-03-11 04:12:11.966 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:11.967 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'ovos_test'
+2026-03-11 04:12:12.298 - configured - ovos_utils.skill_installer:pip_uninstall:330 - ERROR - tried to uninstall a protected package: ['ovos-core']
+2026-03-11 04:12:12.299 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:12.461 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-03-11 04:12:12.462 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /usr/bin/uv pip uninstall -y custom-pkg
+2026-03-11 04:12:12.464 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:12.925 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-03-11 04:12:12.926 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/PycharmProjects/OpenVoiceOS Workspace/ovos-utils/.venv/bin/python3 -m pip uninstall -y custom-pkg
+2026-03-11 04:12:12.929 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:13.262 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-03-11 04:12:13.263 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
+2026-03-11 04:12:13.267 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:13.269 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-03-11 04:12:13.294 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
+2026-03-11 04:12:13.296 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:13.296 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-03-11 04:12:13.297 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
+2026-03-11 04:12:13.298 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:13.569 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-03-11 04:12:13.570 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y --break-system-packages custom-pkg
+2026-03-11 04:12:13.571 - configured - ovos_utils.skill_installer:__init__:146 - INFO - ServiceInstaller registered for service 'svc'
+2026-03-11 04:12:13.859 - configured - ovos_utils.skill_installer:pip_uninstall:344 - INFO - [svc] (pip) Uninstalling custom-pkg
+2026-03-11 04:12:13.859 - configured - ovos_utils.skill_installer:pip_uninstall:348 - DEBUG - /home/miro/.local/bin/uv pip uninstall -y custom-pkg
+2026-03-11 04:12:13.913 - configured - ovos_utils.system:system_reboot:83 - DEBUG - sudo systemctl reboot -i
+2026-03-11 04:12:13.915 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - sudo systemctl poweroff -i
+2026-03-11 04:12:13.916 - configured - ovos_utils.system:system_shutdown:66 - DEBUG - systemctl poweroff -i

--- a/test/unittests/log_test/rotate.log
+++ b/test/unittests/log_test/rotate.log
@@ -1,1 +1,1 @@
-2026-08-01 01:07:13.189 - rotate - ovos_utils.events:EventSchedulerInterface.__init__ - WARNING - Deprecation version=1.0.0. Caller=test_event_scheduler:110. EventSchedulerInterface moved to ovos_bus_client. 'from ovos_bus_client.apis.events import EventSchedulerInterface'
+2026-03-11 04:12:13.924 - rotate - ovos_utils.system:ssh_enable - WARNING - Deprecation version=0.2.0. Caller=test_system:165. DEPRECATED: use ovos-PHAL-plugin-system

--- a/test/unittests/log_test/rotate.log
+++ b/test/unittests/log_test/rotate.log
@@ -1,1 +1,1 @@
-2026-03-11 04:12:13.924 - rotate - ovos_utils.system:ssh_enable - WARNING - Deprecation version=0.2.0. Caller=test_system:165. DEPRECATED: use ovos-PHAL-plugin-system
+2026-08-01 01:07:13.189 - rotate - ovos_utils.events:EventSchedulerInterface.__init__ - WARNING - Deprecation version=1.0.0. Caller=test_event_scheduler:110. EventSchedulerInterface moved to ovos_bus_client. 'from ovos_bus_client.apis.events import EventSchedulerInterface'

--- a/test/unittests/log_test/rotate.log
+++ b/test/unittests/log_test/rotate.log
@@ -1,1 +1,1 @@
-2026-03-11 04:12:13.924 - rotate - ovos_utils.system:ssh_enable - WARNING - Deprecation version=0.2.0. Caller=test_system:165. DEPRECATED: use ovos-PHAL-plugin-system
+2026-08-01 19:07:56.393 - rotate - ovos_utils.system:ssh_enable - WARNING - Deprecation version=0.2.0. Caller=test_system:165. DEPRECATED: use ovos-PHAL-plugin-system

--- a/test/unittests/log_test/rotate.log.1
+++ b/test/unittests/log_test/rotate.log.1
@@ -1,1 +1,1 @@
-2026-08-01 01:07:02.718 - rotate - ovos_utils.sound:_find_player:66 - ERROR - Can't find player for: test.xyz
+2026-03-11 04:12:13.923 - rotate - ovos_utils.system:ssh_disable - WARNING - Deprecation version=0.2.0. Caller=test_system:175. DEPRECATED: use ovos-PHAL-plugin-system

--- a/test/unittests/log_test/rotate.log.1
+++ b/test/unittests/log_test/rotate.log.1
@@ -1,1 +1,1 @@
-2026-03-11 04:12:13.923 - rotate - ovos_utils.system:ssh_disable - WARNING - Deprecation version=0.2.0. Caller=test_system:175. DEPRECATED: use ovos-PHAL-plugin-system
+2026-08-01 01:07:02.718 - rotate - ovos_utils.sound:_find_player:66 - ERROR - Can't find player for: test.xyz

--- a/test/unittests/log_test/rotate.log.1
+++ b/test/unittests/log_test/rotate.log.1
@@ -1,1 +1,1 @@
-2026-03-11 04:12:13.923 - rotate - ovos_utils.system:ssh_disable - WARNING - Deprecation version=0.2.0. Caller=test_system:175. DEPRECATED: use ovos-PHAL-plugin-system
+2026-08-01 19:07:56.390 - rotate - ovos_utils.system:ssh_disable - WARNING - Deprecation version=0.2.0. Caller=test_system:175. DEPRECATED: use ovos-PHAL-plugin-system

--- a/test/unittests/test_fakebus_intent_legacy_reemit.py
+++ b/test/unittests/test_fakebus_intent_legacy_reemit.py
@@ -2,9 +2,13 @@
 
 Old ovos-workshop built the per-intent dispatch topic from the resource
 filename, so ``<skill_id>:food.order.intent`` reached the wire. Current
-workshop registers the canonical ``<skill_id>:food.order``. When emit_legacy
-is on, a bus that has a handler bound to the suffixed spelling also gets the
-dispatch mirrored onto that spelling.
+workshop registers the canonical ``<skill_id>:food.order``. The bridge is two
+stateless rules. The real client splits them over a wire send and a wire
+receive; a fake bus is one process, so both land in ``emit``:
+
+* a CANONICAL dispatch also fires its suffixed twin, marked as a twin;
+* a SUFFIXED dispatch that is not already such a twin also fires its canonical
+  spelling.
 
 Both fake buses must behave like the real client, otherwise every harness
 built on them hides the compat path.
@@ -14,8 +18,7 @@ import unittest
 
 from ovos_spec_tools import Message
 
-from ovos_utils.fakebus import (INTENT_REEMIT_CONTEXT_KEY, AsyncFakeBus,
-                                FakeBus)
+from ovos_utils.fakebus import (INTENT_COMPAT_TWIN_KEY, AsyncFakeBus, FakeBus)
 
 CANONICAL = "skill-food.jarbas:food.order"
 LEGACY = "skill-food.jarbas:food.order.intent"
@@ -25,8 +28,10 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-class TestAliasDrivenReemit(unittest.TestCase):
-    def test_suffixed_subscription_receives_canonical_dispatch(self):
+class TestCanonicalDispatch(unittest.TestCase):
+    """Rule 1: a canonical dispatch also fires the marked suffixed twin."""
+
+    def test_suffixed_handler_receives_the_twin(self):
         bus = FakeBus()
         got = []
         bus.on(LEGACY, got.append)
@@ -34,62 +39,23 @@ class TestAliasDrivenReemit(unittest.TestCase):
         self.assertEqual([m.msg_type for m in got], [LEGACY])
         self.assertEqual(got[0].data, {"utterance": "one pizza"})
 
-    def test_mirror_keeps_data_and_context(self):
+    def test_twin_is_marked_and_keeps_context(self):
         bus = FakeBus()
         got = []
         bus.on(LEGACY, got.append)
         bus.emit(Message(CANONICAL, {"a": 1}, {"source": ["me"]}))
-        self.assertEqual(got[0].data, {"a": 1})
         self.assertEqual(got[0].context["source"], ["me"])
+        self.assertTrue(got[0].context[INTENT_COMPAT_TWIN_KEY])
 
-    def test_mirror_is_marked_in_context(self):
-        bus = FakeBus()
-        got = []
-        bus.on(LEGACY, got.append)
-        bus.emit(Message(CANONICAL))
-        self.assertTrue(got[0].context[INTENT_REEMIT_CONTEXT_KEY])
-
-    def test_no_mirror_without_a_suffixed_subscription(self):
+    def test_canonical_handler_fires_exactly_once(self):
         bus = FakeBus()
         got = []
         bus.on(CANONICAL, got.append)
-        bus.emit(Message(CANONICAL))
-        self.assertEqual([m.msg_type for m in got], [CANONICAL])
-
-    def test_once_subscription_also_registers_the_alias(self):
-        bus = FakeBus()
-        got = []
-        bus.once(LEGACY, got.append)
-        bus.emit(Message(CANONICAL))
-        self.assertEqual([m.msg_type for m in got], [LEGACY])
-
-    def test_non_intent_topics_are_never_mirrored(self):
-        bus = FakeBus()
-        got = []
-        bus.on("ovos.utterance.handled.intent", got.append)
-        bus.emit(Message("ovos.utterance.handled"))
-        self.assertEqual(got, [])
-
-
-class TestExactlyOnce(unittest.TestCase):
-    def test_one_dispatch_yields_one_mirror(self):
-        bus = FakeBus()
-        got = []
-        bus.on(LEGACY, got.append)
+        bus.on(LEGACY, lambda m: None)
         bus.emit(Message(CANONICAL))
         self.assertEqual(len(got), 1)
 
-    def test_two_suffixed_handlers_each_run_once(self):
-        bus = FakeBus()
-        a, b = [], []
-        bus.on(LEGACY, a.append)
-        bus.on(LEGACY, b.append)
-        bus.emit(Message(CANONICAL))
-        self.assertEqual((len(a), len(b)), (1, 1))
-
-    def test_handler_on_both_spellings_gets_both_topics_once_each(self):
-        # the intent bridge does not dedupe across spellings - a handler bound
-        # to both asked for both. Workshop collapses aliases at registration.
+    def test_a_handler_on_both_spellings_hears_both_frames_once_each(self):
         bus = FakeBus()
         got = []
         bus.on(CANONICAL, got.append)
@@ -97,137 +63,89 @@ class TestExactlyOnce(unittest.TestCase):
         bus.emit(Message(CANONICAL))
         self.assertEqual([m.msg_type for m in got], [CANONICAL, LEGACY])
 
-
-class TestLoopPrevention(unittest.TestCase):
-    def test_a_legacy_dispatch_is_not_mirrored_again(self):
-        bus = FakeBus()
-        got = []
-        bus.on(LEGACY, got.append)
-        bus.on(CANONICAL, got.append)
-        bus.emit(Message(LEGACY))
-        self.assertEqual([m.msg_type for m in got], [LEGACY])
-
-    def test_a_marked_message_is_not_mirrored(self):
-        bus = FakeBus()
-        got = []
-        bus.on(LEGACY, got.append)
-        bus.emit(Message(CANONICAL, {}, {INTENT_REEMIT_CONTEXT_KEY: True}))
-        self.assertEqual(got, [])
-
-    def test_reemitting_a_mirror_terminates(self):
-        bus = FakeBus(intent_reemit_blanket=True)
-        got = []
-        bus.on(LEGACY, got.append)
-        bus.emit(Message(CANONICAL))
-        bus.emit(got[0])  # feed the twin back in
-        self.assertEqual(len(got), 2)
-
-
-class TestBlanketMode(unittest.TestCase):
-    def test_blanket_mirrors_without_any_registration(self):
-        bus = FakeBus(intent_reemit_blanket=True)
-        got = []
-        bus.ee.on(LEGACY, got.append)  # subscribe behind the bus's back
-        bus.emit(Message(CANONICAL))
-        self.assertEqual([m.msg_type for m in got], [LEGACY])
-
-    def test_blanket_off_by_default(self):
-        bus = FakeBus()
-        got = []
-        bus.ee.on(LEGACY, got.append)
-        bus.emit(Message(CANONICAL))
-        self.assertEqual(got, [])
-
-    def test_blanket_still_skips_non_intent_topics(self):
-        bus = FakeBus(intent_reemit_blanket=True)
-        got = []
-        bus.ee.on("ovos.utterance.handled.intent", got.append)
-        bus.emit(Message("ovos.utterance.handled"))
-        self.assertEqual(got, [])
-
-
-class TestDisabled(unittest.TestCase):
-    def test_no_mirror_when_emit_legacy_is_off(self):
+    def test_no_twin_when_compat_is_disabled(self):
         bus = FakeBus(emit_legacy=False)
         got = []
         bus.on(LEGACY, got.append)
         bus.emit(Message(CANONICAL))
         self.assertEqual(got, [])
 
-    def test_no_mirror_when_emit_legacy_is_off_even_in_blanket(self):
-        bus = FakeBus(emit_legacy=False, intent_reemit_blanket=True)
-        got = []
-        bus.ee.on(LEGACY, got.append)
-        bus.emit(Message(CANONICAL))
-        self.assertEqual(got, [])
 
-    def test_no_mirror_without_spec_tools_intent_support(self):
+class TestSuffixedDispatch(unittest.TestCase):
+    """Rule 2: an unmarked suffixed dispatch also fires the canonical form."""
+
+    def test_canonical_handler_hears_an_old_style_dispatch(self):
         bus = FakeBus()
-        bus._intent_aliases = None  # older spec-tools: helpers not importable
         got = []
-        bus.ee.on(LEGACY, got.append)
-        bus.emit(Message(CANONICAL))
-        self.assertEqual(got, [])
+        bus.on(CANONICAL, got.append)
+        bus.emit(Message(LEGACY, {"utterance": "one pizza"}))
+        self.assertEqual([m.msg_type for m in got], [CANONICAL])
+        self.assertEqual(got[0].data, {"utterance": "one pizza"})
 
-
-class TestAliasLifecycle(unittest.TestCase):
-    def test_removing_the_last_suffixed_handler_stops_the_mirror(self):
+    def test_suffixed_handler_still_gets_the_original(self):
         bus = FakeBus()
         got = []
         bus.on(LEGACY, got.append)
-        bus.remove(LEGACY, got.append)
-        bus.emit(Message(CANONICAL))
+        bus.emit(Message(LEGACY))
+        self.assertEqual(len(got), 1)
+
+    def test_a_marked_twin_is_not_modernized_again(self):
+        bus = FakeBus()
+        got = []
+        bus.on(CANONICAL, got.append)
+        bus.emit(Message(LEGACY, {}, {INTENT_COMPAT_TWIN_KEY: True}))
         self.assertEqual(got, [])
 
-    def test_remove_all_listeners_stops_the_mirror(self):
+    def test_the_bridge_does_not_cascade(self):
         bus = FakeBus()
         got = []
         bus.on(LEGACY, got.append)
-        bus.remove_all_listeners(LEGACY)
-        bus.emit(Message(CANONICAL))
+        bus.emit(Message(LEGACY))
+        self.assertEqual(len(got), 1)  # not re-twinned off its own canonical
+
+    def test_no_modernization_when_compat_is_disabled(self):
+        bus = FakeBus(emit_legacy=False)
+        got = []
+        bus.on(CANONICAL, got.append)
+        bus.emit(Message(LEGACY))
         self.assertEqual(got, [])
 
-    def test_one_removal_of_two_handlers_keeps_the_mirror(self):
+
+class TestNonIntentTopics(unittest.TestCase):
+    def test_dotted_topics_are_untouched(self):
         bus = FakeBus()
-        a, b = [], []
-        bus.on(LEGACY, a.append)
-        bus.on(LEGACY, b.append)
-        bus.remove(LEGACY, a.append)
-        bus.emit(Message(CANONICAL))
-        self.assertEqual(len(b), 1)
+        got = []
+        bus.on("ovos.utterance.handled", got.append)
+        bus.emit(Message("ovos.utterance.handled"))
+        self.assertEqual(len(got), 1)
+
+    def test_nothing_extra_is_dispatched(self):
+        bus = FakeBus()
+        got = []
+        bus.on("message", got.append)
+        bus.emit(Message("ovos.utterance.handled"))
+        self.assertEqual(len(got), 1)
 
 
-class TestAsyncFakeBusParity(unittest.TestCase):
-    def test_suffixed_subscription_receives_canonical_dispatch(self):
+class TestAsyncFakeBus(unittest.TestCase):
+    """The async double runs the same two rules."""
+
+    def test_canonical_dispatch_fires_the_twin(self):
         bus = AsyncFakeBus()
         got = []
         bus.on(LEGACY, got.append)
-        _run(bus.emit(Message(CANONICAL, {"utterance": "one pizza"})))
+        _run(bus.emit(Message(CANONICAL)))
         self.assertEqual([m.msg_type for m in got], [LEGACY])
-        self.assertEqual(got[0].data, {"utterance": "one pizza"})
+        self.assertTrue(got[0].context[INTENT_COMPAT_TWIN_KEY])
 
-    def test_no_mirror_without_a_suffixed_subscription(self):
+    def test_suffixed_dispatch_fires_the_canonical_form(self):
         bus = AsyncFakeBus()
         got = []
         bus.on(CANONICAL, got.append)
-        _run(bus.emit(Message(CANONICAL)))
+        _run(bus.emit(Message(LEGACY)))
         self.assertEqual([m.msg_type for m in got], [CANONICAL])
 
-    def test_legacy_dispatch_is_not_mirrored_again(self):
-        bus = AsyncFakeBus()
-        got = []
-        bus.on(LEGACY, got.append)
-        _run(bus.emit(Message(LEGACY)))
-        self.assertEqual(len(got), 1)
-
-    def test_blanket_mode(self):
-        bus = AsyncFakeBus(intent_reemit_blanket=True)
-        got = []
-        bus.ee.on(LEGACY, got.append)
-        _run(bus.emit(Message(CANONICAL)))
-        self.assertEqual([m.msg_type for m in got], [LEGACY])
-
-    def test_no_mirror_when_emit_legacy_is_off(self):
+    def test_no_bridge_when_compat_is_disabled(self):
         bus = AsyncFakeBus(emit_legacy=False)
         got = []
         bus.on(LEGACY, got.append)

--- a/test/unittests/test_fakebus_intent_legacy_reemit.py
+++ b/test/unittests/test_fakebus_intent_legacy_reemit.py
@@ -193,6 +193,30 @@ class TestNonIntentTopics(unittest.TestCase):
         self.assertEqual(len(got), 1)
 
 
+class TestBridgeIntentTopicsErrorIsolation(unittest.TestCase):
+    """A raising `_bridge_intent_topics` must not propagate out of emit(),
+    matching the counterpart-topics loop's own try/except + LOG.exception
+    resilience pattern in the same method (CodeRabbit review, #411)."""
+
+    def test_sync_bus_emit_survives_a_raising_bridge(self):
+        bus = FakeBus()
+        bus._bridge_intent_topics = lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("boom"))
+        got = []
+        bus.on(CANONICAL, got.append)
+        bus.emit(Message(CANONICAL))  # must not raise
+        self.assertEqual([m.msg_type for m in got], [CANONICAL])
+
+    def test_async_bus_emit_survives_a_raising_bridge(self):
+        bus = AsyncFakeBus()
+        bus._bridge_intent_topics = lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("boom"))
+        got = []
+        bus.on(CANONICAL, got.append)
+        _run(bus.emit(Message(CANONICAL)))  # must not raise
+        self.assertEqual([m.msg_type for m in got], [CANONICAL])
+
+
 class TestAsyncFakeBus(unittest.TestCase):
     """The async double runs the same two rules."""
 

--- a/test/unittests/test_fakebus_intent_legacy_reemit.py
+++ b/test/unittests/test_fakebus_intent_legacy_reemit.py
@@ -1,0 +1,239 @@
+"""FakeBus mirrors MessageBusClient's legacy intent-topic bridge.
+
+Old ovos-workshop built the per-intent dispatch topic from the resource
+filename, so ``<skill_id>:food.order.intent`` reached the wire. Current
+workshop registers the canonical ``<skill_id>:food.order``. When emit_legacy
+is on, a bus that has a handler bound to the suffixed spelling also gets the
+dispatch mirrored onto that spelling.
+
+Both fake buses must behave like the real client, otherwise every harness
+built on them hides the compat path.
+"""
+import asyncio
+import unittest
+
+from ovos_spec_tools import Message
+
+from ovos_utils.fakebus import (INTENT_REEMIT_CONTEXT_KEY, AsyncFakeBus,
+                                FakeBus)
+
+CANONICAL = "skill-food.jarbas:food.order"
+LEGACY = "skill-food.jarbas:food.order.intent"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestAliasDrivenReemit(unittest.TestCase):
+    def test_suffixed_subscription_receives_canonical_dispatch(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL, {"utterance": "one pizza"}))
+        self.assertEqual([m.msg_type for m in got], [LEGACY])
+        self.assertEqual(got[0].data, {"utterance": "one pizza"})
+
+    def test_mirror_keeps_data_and_context(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL, {"a": 1}, {"source": ["me"]}))
+        self.assertEqual(got[0].data, {"a": 1})
+        self.assertEqual(got[0].context["source"], ["me"])
+
+    def test_mirror_is_marked_in_context(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertTrue(got[0].context[INTENT_REEMIT_CONTEXT_KEY])
+
+    def test_no_mirror_without_a_suffixed_subscription(self):
+        bus = FakeBus()
+        got = []
+        bus.on(CANONICAL, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual([m.msg_type for m in got], [CANONICAL])
+
+    def test_once_subscription_also_registers_the_alias(self):
+        bus = FakeBus()
+        got = []
+        bus.once(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual([m.msg_type for m in got], [LEGACY])
+
+    def test_non_intent_topics_are_never_mirrored(self):
+        bus = FakeBus()
+        got = []
+        bus.on("ovos.utterance.handled.intent", got.append)
+        bus.emit(Message("ovos.utterance.handled"))
+        self.assertEqual(got, [])
+
+
+class TestExactlyOnce(unittest.TestCase):
+    def test_one_dispatch_yields_one_mirror(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(len(got), 1)
+
+    def test_two_suffixed_handlers_each_run_once(self):
+        bus = FakeBus()
+        a, b = [], []
+        bus.on(LEGACY, a.append)
+        bus.on(LEGACY, b.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual((len(a), len(b)), (1, 1))
+
+    def test_handler_on_both_spellings_gets_both_topics_once_each(self):
+        # the intent bridge does not dedupe across spellings - a handler bound
+        # to both asked for both. Workshop collapses aliases at registration.
+        bus = FakeBus()
+        got = []
+        bus.on(CANONICAL, got.append)
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual([m.msg_type for m in got], [CANONICAL, LEGACY])
+
+
+class TestLoopPrevention(unittest.TestCase):
+    def test_a_legacy_dispatch_is_not_mirrored_again(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.on(CANONICAL, got.append)
+        bus.emit(Message(LEGACY))
+        self.assertEqual([m.msg_type for m in got], [LEGACY])
+
+    def test_a_marked_message_is_not_mirrored(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL, {}, {INTENT_REEMIT_CONTEXT_KEY: True}))
+        self.assertEqual(got, [])
+
+    def test_reemitting_a_mirror_terminates(self):
+        bus = FakeBus(intent_reemit_blanket=True)
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        bus.emit(got[0])  # feed the twin back in
+        self.assertEqual(len(got), 2)
+
+
+class TestBlanketMode(unittest.TestCase):
+    def test_blanket_mirrors_without_any_registration(self):
+        bus = FakeBus(intent_reemit_blanket=True)
+        got = []
+        bus.ee.on(LEGACY, got.append)  # subscribe behind the bus's back
+        bus.emit(Message(CANONICAL))
+        self.assertEqual([m.msg_type for m in got], [LEGACY])
+
+    def test_blanket_off_by_default(self):
+        bus = FakeBus()
+        got = []
+        bus.ee.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(got, [])
+
+    def test_blanket_still_skips_non_intent_topics(self):
+        bus = FakeBus(intent_reemit_blanket=True)
+        got = []
+        bus.ee.on("ovos.utterance.handled.intent", got.append)
+        bus.emit(Message("ovos.utterance.handled"))
+        self.assertEqual(got, [])
+
+
+class TestDisabled(unittest.TestCase):
+    def test_no_mirror_when_emit_legacy_is_off(self):
+        bus = FakeBus(emit_legacy=False)
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(got, [])
+
+    def test_no_mirror_when_emit_legacy_is_off_even_in_blanket(self):
+        bus = FakeBus(emit_legacy=False, intent_reemit_blanket=True)
+        got = []
+        bus.ee.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(got, [])
+
+    def test_no_mirror_without_spec_tools_intent_support(self):
+        bus = FakeBus()
+        bus._intent_aliases = None  # older spec-tools: helpers not importable
+        got = []
+        bus.ee.on(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(got, [])
+
+
+class TestAliasLifecycle(unittest.TestCase):
+    def test_removing_the_last_suffixed_handler_stops_the_mirror(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.remove(LEGACY, got.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(got, [])
+
+    def test_remove_all_listeners_stops_the_mirror(self):
+        bus = FakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        bus.remove_all_listeners(LEGACY)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(got, [])
+
+    def test_one_removal_of_two_handlers_keeps_the_mirror(self):
+        bus = FakeBus()
+        a, b = [], []
+        bus.on(LEGACY, a.append)
+        bus.on(LEGACY, b.append)
+        bus.remove(LEGACY, a.append)
+        bus.emit(Message(CANONICAL))
+        self.assertEqual(len(b), 1)
+
+
+class TestAsyncFakeBusParity(unittest.TestCase):
+    def test_suffixed_subscription_receives_canonical_dispatch(self):
+        bus = AsyncFakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        _run(bus.emit(Message(CANONICAL, {"utterance": "one pizza"})))
+        self.assertEqual([m.msg_type for m in got], [LEGACY])
+        self.assertEqual(got[0].data, {"utterance": "one pizza"})
+
+    def test_no_mirror_without_a_suffixed_subscription(self):
+        bus = AsyncFakeBus()
+        got = []
+        bus.on(CANONICAL, got.append)
+        _run(bus.emit(Message(CANONICAL)))
+        self.assertEqual([m.msg_type for m in got], [CANONICAL])
+
+    def test_legacy_dispatch_is_not_mirrored_again(self):
+        bus = AsyncFakeBus()
+        got = []
+        bus.on(LEGACY, got.append)
+        _run(bus.emit(Message(LEGACY)))
+        self.assertEqual(len(got), 1)
+
+    def test_blanket_mode(self):
+        bus = AsyncFakeBus(intent_reemit_blanket=True)
+        got = []
+        bus.ee.on(LEGACY, got.append)
+        _run(bus.emit(Message(CANONICAL)))
+        self.assertEqual([m.msg_type for m in got], [LEGACY])
+
+    def test_no_mirror_when_emit_legacy_is_off(self):
+        bus = AsyncFakeBus(emit_legacy=False)
+        got = []
+        bus.on(LEGACY, got.append)
+        _run(bus.emit(Message(CANONICAL)))
+        self.assertEqual(got, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_fakebus_intent_legacy_reemit.py
+++ b/test/unittests/test_fakebus_intent_legacy_reemit.py
@@ -39,13 +39,28 @@ class TestCanonicalDispatch(unittest.TestCase):
         self.assertEqual([m.msg_type for m in got], [LEGACY])
         self.assertEqual(got[0].data, {"utterance": "one pizza"})
 
-    def test_twin_is_marked_and_keeps_context(self):
+    def test_twin_keeps_context_but_is_delivered_unmarked(self):
+        # the twin keeps the ordinary context it forwards, but the dedup marker
+        # must NOT reach local handlers: it would ride forward()/reply() onto
+        # any follow-up message a handler emits and suppress its modernization.
         bus = FakeBus()
         got = []
         bus.on(LEGACY, got.append)
         bus.emit(Message(CANONICAL, {"a": 1}, {"source": ["me"]}))
         self.assertEqual(got[0].context["source"], ["me"])
-        self.assertTrue(got[0].context[INTENT_COMPAT_TWIN_KEY])
+        self.assertNotIn(INTENT_COMPAT_TWIN_KEY, got[0].context)
+
+    def test_twin_carries_the_marker_on_the_wire(self):
+        # wire survival: the serialized twin on the "message" firehose keeps the
+        # marker, so a receiver in another process still skips re-modernizing it.
+        import json
+        bus = FakeBus()
+        wire = []
+        bus.on("message", lambda m: wire.append(json.loads(m)))
+        bus.emit(Message(CANONICAL))
+        twins = [f for f in wire if f["type"] == LEGACY]
+        self.assertEqual(len(twins), 1)
+        self.assertTrue(twins[0]["context"][INTENT_COMPAT_TWIN_KEY])
 
     def test_canonical_handler_fires_exactly_once(self):
         bus = FakeBus()
@@ -111,6 +126,57 @@ class TestSuffixedDispatch(unittest.TestCase):
         self.assertEqual(got, [])
 
 
+class TestMarkerDoesNotLeakToDescendants(unittest.TestCase):
+    """The twin marker must not ride forward()/reply() onto later messages.
+
+    Message.forward()/reply() deep-copy the whole context. If a delivered twin
+    kept the marker, a handler that forwards that context to emit an UNRELATED
+    suffixed intent would brand the follow-up a twin, and the bridge would
+    silently drop its canonical spelling.
+    """
+
+    UNRELATED_LEGACY = "other-skill.jarbas:unrelated.intent"
+    UNRELATED_CANON = "other-skill.jarbas:unrelated"
+
+    def test_forward_off_a_twin_does_not_suppress_an_unrelated_intent(self):
+        bus = FakeBus()
+        seen_twin = []
+        bus.on(LEGACY, seen_twin.append)
+        bus.emit(Message(CANONICAL, {"utterance": "one pizza"}))
+        twin_msg = seen_twin[0]
+        self.assertNotIn(INTENT_COMPAT_TWIN_KEY, twin_msg.context)
+        # a handler forwards this frame's context to emit an unrelated intent.
+        got_canon = []
+        bus.on(self.UNRELATED_CANON, got_canon.append)
+        followup = twin_msg.forward(self.UNRELATED_LEGACY, {})
+        self.assertNotIn(INTENT_COMPAT_TWIN_KEY, followup.context)
+        bus.emit(followup)
+        # the unrelated canonical topic IS modernized: the marker did not leak.
+        self.assertEqual([m.msg_type for m in got_canon], [self.UNRELATED_CANON])
+
+    def test_reply_off_a_twin_does_not_suppress_an_unrelated_intent(self):
+        bus = FakeBus()
+        seen_twin = []
+        bus.on(LEGACY, seen_twin.append)
+        bus.emit(Message(CANONICAL))
+        got_canon = []
+        bus.on(self.UNRELATED_CANON, got_canon.append)
+        bus.emit(seen_twin[0].reply(self.UNRELATED_LEGACY, {}))
+        self.assertEqual([m.msg_type for m in got_canon], [self.UNRELATED_CANON])
+
+    def test_marker_survives_on_the_wire_for_a_second_receiver(self):
+        # a marked frame emitted (as if arriving from the wire) is delivered to
+        # its legacy listener but NOT re-modernized: wire survival intact.
+        bus = FakeBus()
+        got_legacy = []
+        got_canon = []
+        bus.on(LEGACY, got_legacy.append)
+        bus.on(CANONICAL, got_canon.append)
+        bus.emit(Message(LEGACY, {}, {INTENT_COMPAT_TWIN_KEY: True}))
+        self.assertEqual(len(got_legacy), 1)
+        self.assertEqual(len(got_canon), 0)
+
+
 class TestNonIntentTopics(unittest.TestCase):
     def test_dotted_topics_are_untouched(self):
         bus = FakeBus()
@@ -136,7 +202,8 @@ class TestAsyncFakeBus(unittest.TestCase):
         bus.on(LEGACY, got.append)
         _run(bus.emit(Message(CANONICAL)))
         self.assertEqual([m.msg_type for m in got], [LEGACY])
-        self.assertTrue(got[0].context[INTENT_COMPAT_TWIN_KEY])
+        # delivered unmarked (no leak onto descendants); marker rides the wire
+        self.assertNotIn(INTENT_COMPAT_TWIN_KEY, got[0].context)
 
     def test_suffixed_dispatch_fires_the_canonical_form(self):
         bus = AsyncFakeBus()


### PR DESCRIPTION
## Why

OVOS-MSG-1 §2.1.1 assembles the per-intent dispatch topic at runtime as `<skill_id>:<intent_name>`. Old `ovos-workshop` releases built it from the padatious resource **filename**, so a skill with `food.order.intent` registered and listened on `<skill_id>:food.order.intent`. Current workshop is spec-pure and registers `<skill_id>:food.order`.

`ovos-bus-client#271` makes the real client bridge the two spellings when `emit_legacy` is on. This PR gives the test doubles the same behavior. Without it every harness built on `FakeBus` — ovoscope, the skill test suites, the satellite fakes — hides the compat path, and a skill that passes its tests still misses the dispatch on a real bus.

The version skew this covers is unchanged from the outside:

| | old core (dispatches `X:Y.intent`) | new core (dispatches `X:Y`) |
|---|---|---|
| **old skill** (listens `X:Y.intent`) | works today, untouched | **twin** (rule 1) |
| **new skill** (listens `X:Y`) | **modernize** (rule 2) | works today, untouched |

## Design: two stateless rules

Per the maintainer-approved simplification, the compat layer is two `if` blocks and nothing else:

**RULE 1.** A **canonical** intent dispatch also fires its `legacy_intent_topic` twin, carrying an `_intent_compat_twin: True` context marker.

**RULE 2.** A **suffixed** intent dispatch that is not already such a twin also fires its `canonical_intent_topic` form.

The real client splits these over a wire send and a wire receive; a fake bus is one process, so both land in `emit()`, right after the existing `counterpart_topics()` dispatch. The two cases are mutually exclusive and neither cascades, so one emit reaches each handler exactly once — provable by inspection, with no bookkeeping to audit.

**Kill-switch: delete the two `if` blocks.** Until then the bridge rides the existing `emit_legacy` flag, the same one the namespace bridge uses. There is no second flag.

### What the previous revision had, and why it is gone

`IntentAliasRegistry`, the per-bus alias table, the `on()` / `once()` / `remove()` / `remove_all_listeners()` bookkeeping that maintained it, and the `intent_reemit_blanket` flag (blanket **is** the behavior now) are all removed. The bridge does not need to know which handlers exist: a twin nobody listens to is a few ignored bytes.

`_LegacyIntentBridge` stays as the mixin shared by `FakeBus` and `AsyncFakeBus`, so the two doubles cannot drift, but it now holds one stateless method.

## Dependency order

1. **ovos-spec-tools#88** — the pure helpers. Released as 1.6.0a1; the floor here is raised to it.
2. **ovos-spec-tools#92** — removes `IntentAliasRegistry` and `legacy_reemit_targets`. **No follow-up floor bump is needed here**: after this rewrite `fakebus.py` imports only `canonical_intent_topic`, `legacy_intent_topic`, and `is_intent_topic`, all present in 1.6.0a1.
3. **ovos-workshop#500** — registration becomes canonical-only.
4. **ovos-bus-client#271** + this PR — the two rules execute in both bus layers.
5. **ovoscope#127** / the ovos-core guards — the strict-xfail guards flip once the double behaves like the real bus.

## Non-normative

No specification mandates the suffixed topic or the twin. This is transitional tooling scoped to the migration period. New code must produce and consume canonical topics only.

## Tests

`test/unittests/test_fakebus_intent_legacy_reemit.py`, **15 tests** (was 26): rule 1 (twin fired, marked, payload and context kept, canonical handler still once, a handler on both spellings hears both frames once each, nothing when compat is off); rule 2 (canonical handler hears an old-style dispatch, suffixed handler still gets the original, a marked twin is not modernized again, no cascade, nothing when compat is off); non-intent topics untouched; `AsyncFakeBus` parity on both rules and the off switch.

Full suite: 951 passed, 1 skipped, 1 pre-existing `test_events.py::TestEventSchedulerInterface::test_00_init` failure also present on `dev`.

---
Implemented by Claude (opus), orchestrated by Claude Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved legacy intent-topic compatibility for synchronous and asynchronous FakeBus messaging.
  - Intent events now support both canonical and legacy topic formats while preventing duplicate or recursive dispatch.
  - Compatibility markers are preserved for firehose consumers but hidden from local handlers.

- **Bug Fixes**
  - Prevented legacy intent events from cascading through descendant handlers or being delivered multiple times.

- **Tests**
  - Added comprehensive coverage for topic bridging, deduplication, marker handling, non-intent topics, and asynchronous dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->