### PR TITLE
Add reusable latency histogram helpers

### DIFF
--- a/ovos_utils/metrics.py
+++ b/ovos_utils/metrics.py
@@ -1,4 +1,133 @@
 import time
+import math
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from functools import wraps
+from threading import Lock
+from typing import Any, ParamSpec, TypeVar
+
+
+DEFAULT_LATENCY_BUCKETS_MS = (
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    25.0,
+    50.0,
+    100.0,
+    250.0,
+    500.0,
+    1_000.0,
+    2_500.0,
+    5_000.0,
+    10_000.0,
+    30_000.0,
+)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+class LatencyMeasurement:
+    """A pausable, single-observation monotonic latency measurement."""
+
+    def __init__(self, histogram: "LatencyHistogram") -> None:
+        self._histogram = histogram
+        self._started = time.monotonic()
+        self._elapsed_ms = 0.0
+        self._running = True
+        self._finished = False
+
+    def pause(self) -> None:
+        """Exclude subsequent time until :meth:`resume` is called."""
+        if self._running and not self._finished:
+            self._elapsed_ms += (time.monotonic() - self._started) * 1_000
+            self._running = False
+
+    def resume(self) -> None:
+        """Resume measuring after a pause."""
+        if not self._running and not self._finished:
+            self._started = time.monotonic()
+            self._running = True
+
+    def finish(self) -> None:
+        """Record accumulated active time exactly once."""
+        if self._finished:
+            return
+        self.pause()
+        self._finished = True
+        self._histogram.observe_ms(self._elapsed_ms)
+
+
+class LatencyHistogram:
+    """Thread-safe cumulative latency histogram with fixed buckets."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        buckets_ms: Iterable[float] = DEFAULT_LATENCY_BUCKETS_MS,
+    ) -> None:
+        bounds = tuple(sorted(float(value) for value in buckets_ms))
+        if any(not math.isfinite(value) or value < 0 for value in bounds):
+            raise ValueError("buckets_ms must be finite and non-negative")
+        if any(left == right for left, right in zip(bounds, bounds[1:])):
+            raise ValueError("buckets_ms must not contain duplicates")
+        self.name = name
+        self._bounds = bounds
+        self._buckets = [0] * len(bounds)
+        self._count = 0
+        self._sum_ms = 0.0
+        self._lock = Lock()
+
+    def observe_ms(self, elapsed_ms: float) -> None:
+        """Record one finite, non-negative duration in milliseconds."""
+        if isinstance(elapsed_ms, bool):
+            raise TypeError("elapsed_ms must be numeric")
+        value = float(elapsed_ms)
+        if not math.isfinite(value):
+            raise ValueError("elapsed_ms must be finite")
+        value = max(0.0, value)
+        with self._lock:
+            self._count += 1
+            self._sum_ms += value
+            for index, bound in enumerate(self._bounds):
+                if value <= bound:
+                    self._buckets[index] += 1
+
+    @contextmanager
+    def measure(self) -> Iterator[LatencyMeasurement]:
+        """Record active enclosed time, including exceptional exits."""
+        measurement = LatencyMeasurement(self)
+        try:
+            yield measurement
+        finally:
+            measurement.finish()
+
+    def timed(self, function: Callable[P, R]) -> Callable[P, R]:
+        """Decorate a synchronous function with this histogram."""
+
+        @wraps(function)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+            with self.measure():
+                return function(*args, **kwargs)
+
+        return wrapped
+
+    def snapshot(self) -> Mapping[str, Any]:
+        """Return a detached, JSON-friendly cumulative snapshot."""
+        with self._lock:
+            buckets = {
+                f"le_{bound:g}": count
+                for bound, count in zip(self._bounds, self._buckets, strict=True)
+            }
+            buckets["inf"] = self._count
+            return {
+                "name": self.name,
+                "count": self._count,
+                "sum_ms": self._sum_ms,
+                "buckets": buckets,
+            }
 
 
 class Stopwatch:

--- a/ovos_utils/metrics.py
+++ b/ovos_utils/metrics.py
@@ -37,26 +37,35 @@ class LatencyMeasurement:
         self._elapsed_ms = 0.0
         self._running = True
         self._finished = False
+        self._lock = Lock()
 
     def pause(self) -> None:
         """Exclude subsequent time until :meth:`resume` is called."""
-        if self._running and not self._finished:
-            self._elapsed_ms += (time.monotonic() - self._started) * 1_000
-            self._running = False
+        with self._lock:
+            if self._running and not self._finished:
+                self._elapsed_ms += (time.monotonic() - self._started) * 1_000
+                self._running = False
 
     def resume(self) -> None:
         """Resume measuring after a pause."""
-        if not self._running and not self._finished:
-            self._started = time.monotonic()
-            self._running = True
+        with self._lock:
+            if not self._running and not self._finished:
+                self._started = time.monotonic()
+                self._running = True
 
     def finish(self) -> None:
         """Record accumulated active time exactly once."""
-        if self._finished:
-            return
-        self.pause()
-        self._finished = True
-        self._histogram.observe_ms(self._elapsed_ms)
+        with self._lock:
+            if self._finished:
+                return
+            if self._running:
+                self._elapsed_ms += (
+                    time.monotonic() - self._started
+                ) * 1_000
+                self._running = False
+            self._finished = True
+            elapsed_ms = self._elapsed_ms
+        self._histogram.observe_ms(elapsed_ms)
 
 
 class LatencyHistogram:
@@ -118,7 +127,7 @@ class LatencyHistogram:
         """Return a detached, JSON-friendly cumulative snapshot."""
         with self._lock:
             buckets = {
-                f"le_{bound:g}": count
+                f"le_{format(bound, '.17g')}": count
                 for bound, count in zip(self._bounds, self._buckets, strict=True)
             }
             buckets["inf"] = self._count

--- a/test/unittests/test_metrics.py
+++ b/test/unittests/test_metrics.py
@@ -3,10 +3,95 @@
 
 import time
 import unittest
-from ovos_utils.metrics import Stopwatch
+from unittest.mock import patch
+
+from ovos_utils.metrics import LatencyHistogram, Stopwatch
 
 
 class MetricsTests(unittest.TestCase):
+    def test_latency_histogram_snapshot(self):
+        histogram = LatencyHistogram("handler_ms", buckets_ms=(1, 5, 10))
+        histogram.observe_ms(0.5)
+        histogram.observe_ms(5)
+        histogram.observe_ms(12)
+
+        self.assertEqual(
+            histogram.snapshot(),
+            {
+                "name": "handler_ms",
+                "count": 3,
+                "sum_ms": 17.5,
+                "buckets": {
+                    "le_1": 1,
+                    "le_5": 2,
+                    "le_10": 2,
+                    "inf": 3,
+                },
+            },
+        )
+
+    def test_latency_histogram_rejects_malformed_values(self):
+        with self.assertRaises(ValueError):
+            LatencyHistogram("duplicate_ms", buckets_ms=(1, 1))
+        with self.assertRaises(ValueError):
+            LatencyHistogram("negative_ms", buckets_ms=(-1, 1))
+        with self.assertRaises(ValueError):
+            LatencyHistogram("infinite_ms", buckets_ms=(1, float("inf")))
+
+        histogram = LatencyHistogram("handler_ms")
+        with self.assertRaises(TypeError):
+            histogram.observe_ms(True)
+        with self.assertRaises(ValueError):
+            histogram.observe_ms(float("nan"))
+        histogram.observe_ms(-1)
+        self.assertEqual(histogram.snapshot()["sum_ms"], 0)
+
+    @patch("ovos_utils.metrics.time.monotonic")
+    def test_latency_histogram_pauses_and_finishes_once(self, monotonic):
+        monotonic.side_effect = (0.0, 0.1, 1.0, 1.2)
+        histogram = LatencyHistogram("selection_ms", buckets_ms=(250, 500))
+
+        with histogram.measure() as measurement:
+            measurement.pause()
+            measurement.resume()
+        measurement.finish()
+
+        snapshot = histogram.snapshot()
+        self.assertEqual(snapshot["count"], 1)
+        self.assertAlmostEqual(snapshot["sum_ms"], 300)
+        self.assertEqual(
+            snapshot["buckets"],
+            {
+                "le_250": 0,
+                "le_500": 1,
+                "inf": 1,
+            },
+        )
+
+    @patch("ovos_utils.metrics.time.monotonic", side_effect=(2.0, 2.025))
+    def test_latency_histogram_records_exceptional_exit(self, _monotonic):
+        histogram = LatencyHistogram("handler_ms", buckets_ms=(25, 50))
+
+        with self.assertRaisesRegex(RuntimeError, "handler failed"):
+            with histogram.measure():
+                raise RuntimeError("handler failed")
+
+        self.assertEqual(histogram.snapshot()["count"], 1)
+        self.assertAlmostEqual(histogram.snapshot()["sum_ms"], 25)
+
+    @patch("ovos_utils.metrics.time.monotonic", side_effect=(4.0, 4.01))
+    def test_latency_histogram_timed_preserves_metadata(self, _monotonic):
+        histogram = LatencyHistogram("decorated_ms", buckets_ms=(10, 25))
+
+        @histogram.timed
+        def measured(value):
+            """Return the measured value."""
+            return value
+
+        self.assertEqual(measured("ok"), "ok")
+        self.assertEqual(measured.__name__, "measured")
+        self.assertEqual(histogram.snapshot()["count"], 1)
+        self.assertAlmostEqual(histogram.snapshot()["sum_ms"], 10)
 
     def test_stopwatch_simple(self):
         sleep_time = 1.00
@@ -115,7 +200,6 @@ class MetricsTests(unittest.TestCase):
         sw.start()
         time.sleep(0.05)
         sw.stop()
-        old_time = sw.time
         sw.start()
         self.assertIsNone(sw.time)  # reset on start
 

--- a/test/unittests/test_metrics.py
+++ b/test/unittests/test_metrics.py
@@ -3,6 +3,7 @@
 
 import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 from ovos_utils.metrics import LatencyHistogram, Stopwatch
@@ -46,6 +47,16 @@ class MetricsTests(unittest.TestCase):
         histogram.observe_ms(-1)
         self.assertEqual(histogram.snapshot()["sum_ms"], 0)
 
+    def test_latency_histogram_preserves_close_bucket_bounds(self):
+        bounds = (1.0000001, 1.0000002)
+        histogram = LatencyHistogram("precise_ms", buckets_ms=bounds)
+        histogram.observe_ms(bounds[0])
+
+        buckets = histogram.snapshot()["buckets"]
+        self.assertEqual(buckets[f"le_{format(bounds[0], '.17g')}"], 1)
+        self.assertEqual(buckets[f"le_{format(bounds[1], '.17g')}"], 1)
+        self.assertEqual(len(buckets), 3)
+
     @patch("ovos_utils.metrics.time.monotonic")
     def test_latency_histogram_pauses_and_finishes_once(self, monotonic):
         monotonic.side_effect = (0.0, 0.1, 1.0, 1.2)
@@ -67,6 +78,18 @@ class MetricsTests(unittest.TestCase):
                 "inf": 1,
             },
         )
+
+    def test_latency_measurement_finish_is_thread_safe(self):
+        histogram = LatencyHistogram("concurrent_ms")
+        context = histogram.measure()
+        measurement = context.__enter__()
+        measurement.pause()
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(lambda _: measurement.finish(), range(32)))
+
+        context.__exit__(None, None, None)
+        self.assertEqual(histogram.snapshot()["count"], 1)
 
     @patch("ovos_utils.metrics.time.monotonic", side_effect=(2.0, 2.025))
     def test_latency_histogram_records_exceptional_exit(self, _monotonic):


### PR DESCRIPTION
## Summary

Add reusable, dependency-free latency histogram primitives to `ovos_utils.metrics`:

- monotonic timing with pause/resume support;
- thread-safe, fixed cumulative buckets;
- idempotent completion and exception-safe context management;
- a synchronous decorator that preserves wrapped metadata; and
- detached JSON-friendly snapshots for plugin-owned exporters.

## Why

OVOS Core, Workshop, and intent pipeline packages need the same low-level timing and histogram storage without importing one another or creating a dependency cycle. This keeps metric ownership in each instrumented package while giving their process-local metrics providers one shared implementation.

The helper intentionally has no Prometheus server, labels, request identifiers, or runtime policy. Export remains the host runtime's responsibility through the existing metrics-provider entry point.

This is the prerequisite proposed in the architecture discussion on OpenVoiceOS/ovos-workshop#509. Consumer PRs can switch to this API after an `ovos-utils` alpha containing it is published, with explicit minimum-version bumps.

## Validation

- `ruff check ovos_utils/metrics.py test/unittests/test_metrics.py`
- `PYTHONPATH=. pytest -q test/unittests/test_metrics.py` — 19 passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added latency tracking with configurable measurement buckets.
  * Added context-manager timing for measuring operations, including pause and resume support.
  * Added function timing support that preserves existing function metadata.
  * Added JSON-friendly latency snapshots with cumulative counts and timing data.

* **Bug Fixes**
  * Ensured invalid durations and bucket configurations are rejected.
  * Ensured each measurement is recorded exactly once, including when operations exit with errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->