### PR TITLE
docs(fakebus): clarify single-connection model for intent-topic bridge

### DIFF
--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -257,6 +257,26 @@ class FakeBus:
         ``FakeBus`` has no wire hop to put it on, so it keeps the
         single-process harness's one-emit-one-capture invariant instead of
         reproducing the wire's two-frame shape.
+
+        Plain-English note on what this can and cannot represent for tests:
+        a ``FakeBus`` models ONE bus connection, with the same per-client
+        intent-pair dedup guard (see :meth:`_mirror_guard_for`) that a real
+        ``MessageBusClient`` uses. So within one ``FakeBus``, if both
+        spellings of an intent topic have subscribers, only the spelling
+        actually emitted (or its canonical modernization) gets delivered --
+        the mirrored twin/modernized frame is deduped away, and a
+        legacy-only listener starves on a canonical emit. That is exactly
+        what would happen sharing a single real client connection too, so
+        it is not a ``FakeBus`` bug.
+        What a ``FakeBus`` cannot represent is multiple bus CONNECTIONS: on
+        a real wire, a separate connection -- e.g. an external observer
+        process -- receives both spellings, because each connection runs
+        its own independent dedup guard. Tests that attach an observer to
+        the same ``FakeBus`` the skill under test uses are simulating that
+        second connection with the first connection's guard, so the
+        observer should subscribe to the canonical topic
+        (``ovos_spec_tools.intent_topics.canonical_intent_topic``) rather
+        than assuming it will see both spellings.
         """
         # RULE 2 (receive-side modernize): a suffixed frame WITHOUT the twin
         # marker came from an emitter old enough to only put the legacy


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

A downstream team recently re-derived FakeBus's intent-pair dedup guard as a bug: they attached a second listener to the same FakeBus instance to observe both the legacy and canonical spellings of an intent topic, and only ever saw one delivery. That is correct behavior — a FakeBus models one bus connection, and one real MessageBusClient connection only delivers one spelling too. But nothing in the docstring said so, and the guard-scope explanation right next to it is dense enough that the single-connection assumption is easy to miss.

This PR only adds a short plain-English paragraph to the `_bridge_intent_topic` docstring in `ovos_utils/fakebus.py`, explaining what FakeBus can and cannot represent (one connection, not multiple), and pointing test observers at the canonical topic. No behavior changes; `test/unittests/test_fakebus_intent_topic_bridge.py` (12 tests) still passes.
