### PR TITLE
fix: close leaked DNS-probe socket, silence deprecation warning noise

### DIFF
--- a/ovos_utils/network_utils.py
+++ b/ovos_utils/network_utils.py
@@ -94,14 +94,16 @@ def is_connected_dns(host: Optional[str] = None, port: int = 53,
         return is_connected_dns(cfg.get("dns_primary") or _DEFAULT_TEST_CONFIG['dns_primary']) or \
             is_connected_dns(cfg.get("dns_secondary") or _DEFAULT_TEST_CONFIG['dns_secondary'])
 
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         # connect to the host -- tells us if the host is actually reachable
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(timeout)
         s.connect((host, port))
         return True
     except OSError:
         pass
+    finally:
+        s.close()
     return False
 
 

--- a/test/unittests/dialog/test_dialog.py
+++ b/test/unittests/dialog/test_dialog.py
@@ -17,8 +17,26 @@ import unittest
 import pathlib
 import json
 
+import pytest
 
 from ovos_utils.dialog import MustacheDialogRenderer, load_dialogs, get_dialog
+
+# ovos_utils.dialog is a deprecated shim; this module deliberately keeps
+# exercising it for coverage, filtered per-module rather than dropped.
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:MustacheDialogRenderer is deprecated; use the OVOS-INTENT-2:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:get_dialog is deprecated; use the OVOS-INTENT-2:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:load_dialogs is deprecated; use 'ovos_spec_tools.LocaleResources':DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:EventSchedulerInterface moved to ovos_bus_client:DeprecationWarning"
+    ),
+]
 
 
 # TODO - move to ovos-workshop
@@ -33,13 +51,15 @@ class DialogTest(unittest.TestCase):
         for file in template_path.iterdir():
             if file.suffix == '.dialog':
                 self.stache.load_template_file(file.name, str(file.absolute()))
-                context = json.load(
-                    file.with_suffix('.context.json').open(
-                        'r', encoding='utf-8'))
+                with file.with_suffix('.context.json').open(
+                        'r', encoding='utf-8') as f:
+                    context = json.load(f)
+                with file.with_suffix('.result').open(
+                        'r', encoding='utf-8') as f:
+                    expected = f.read()
                 self.assertEqual(
                     self.stache.render(file.name, context),
-                    file.with_suffix('.result').open('r',
-                                                     encoding='utf-8').read())
+                    expected)
 
     def test_unknown_dialog(self):
         """ Test for returned file name literals in case of unkown dialog """
@@ -55,13 +75,12 @@ class DialogTest(unittest.TestCase):
         for file in template_path.iterdir():
             if file.suffix == '.dialog':
                 self.stache.load_template_file(file.name, str(file.absolute()))
-                context = json.load(
-                    file.with_suffix('.context.json').open(
-                        'r', encoding='utf-8'))
-                results = [
-                    line.strip() for line in file.with_suffix('.result').open(
-                        'r', encoding='utf-8')
-                ]
+                with file.with_suffix('.context.json').open(
+                        'r', encoding='utf-8') as f:
+                    context = json.load(f)
+                with file.with_suffix('.result').open(
+                        'r', encoding='utf-8') as fh:
+                    results = [line.strip() for line in fh]
                 # Try all lines
                 for index, line in enumerate(results):
                     self.assertEqual(
@@ -82,8 +101,8 @@ class DialogTest(unittest.TestCase):
         for f in template_path.iterdir():
             if f.suffix == '.dialog':
                 self.stache.load_template_file(f.name, str(f.absolute()))
-                results = [line.strip()
-                           for line in f.with_suffix('.result').open('r')]
+                with f.with_suffix('.result').open('r') as fh:
+                    results = [line.strip() for line in fh]
                 # Try all lines
                 for index, line in enumerate(results):
                     self.assertEqual(self.stache.render(f.name, index=index),

--- a/test/unittests/test_bracket_expansion.py
+++ b/test/unittests/test_bracket_expansion.py
@@ -1,6 +1,14 @@
 import unittest
 
+import pytest
+
 from ovos_utils.bracket_expansion import expand_template, expand_slots
+
+# expand_template is a deprecated shim (use ovos_spec_tools.expand); this
+# module deliberately keeps exercising it for coverage, filtered per-module.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:expand_template is deprecated; import 'expand' from 'ovos_spec_tools':DeprecationWarning"
+)
 
 
 class TestTemplateExpansion(unittest.TestCase):

--- a/test/unittests/test_device_input.py
+++ b/test/unittests/test_device_input.py
@@ -17,12 +17,18 @@
 import sys
 import types
 import unittest
+import warnings
 from unittest import mock
 from unittest.mock import Mock, MagicMock, patch
 
-# distutils was removed in Python 3.12+; provide a minimal stub if missing
+# distutils was removed in Python 3.12+; provide a minimal stub if missing.
+# On older interpreters it still exists but is itself deprecated -- that's
+# the stdlib's own noise, not ours to fix here, so it's suppressed locally.
 try:
-    import distutils.spawn
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning,
+                                message="The distutils package is deprecated")
+        import distutils.spawn
 except ImportError:
     distutils_stub = types.ModuleType("distutils")
     spawn_stub = types.ModuleType("distutils.spawn")

--- a/test/unittests/test_dialog.py
+++ b/test/unittests/test_dialog.py
@@ -19,6 +19,23 @@ import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
 
+import pytest
+
+# ovos_utils.dialog is a deprecated shim (superseded by ovos_spec_tools'
+# dialog renderer); this module deliberately keeps exercising it for
+# coverage, filtered per-module rather than dropped.
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:MustacheDialogRenderer is deprecated; use the OVOS-INTENT-2:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:get_dialog is deprecated; use the OVOS-INTENT-2:DeprecationWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:load_dialogs is deprecated; use 'ovos_spec_tools.LocaleResources':DeprecationWarning"
+    ),
+]
+
 
 class TestMustacheDialogRenderer(unittest.TestCase):
     """Tests for MustacheDialogRenderer class."""

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -6,6 +6,8 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from ovos_bus_client.util.scheduler import EventScheduler
 from ovos_utils.events import EventSchedulerInterface
 from ovos_utils.fakebus import FakeBus
@@ -102,6 +104,7 @@ class TestEventScheduler(unittest.TestCase):
         es.shutdown()
 
 
+@pytest.mark.filterwarnings("ignore:EventSchedulerInterface moved to ovos_bus_client:DeprecationWarning")
 class TestEventSchedulerInterface(unittest.TestCase):
     def test_shutdown(self):
         def f(message):

--- a/test/unittests/test_events.py
+++ b/test/unittests/test_events.py
@@ -1,13 +1,22 @@
 import inspect
 import unittest
 import datetime
+import warnings
 
 from os.path import join, dirname
 from threading import Event
 from time import time
 from unittest.mock import Mock
 
+import pytest
+
 from ovos_utils.fakebus import FakeBus, FakeMessage as Message
+
+# EventSchedulerInterface is a deprecated shim (moved to ovos_bus_client);
+# these classes deliberately keep exercising it for coverage.
+_ignore_event_scheduler_moved = pytest.mark.filterwarnings(
+    "ignore:EventSchedulerInterface moved to ovos_bus_client:DeprecationWarning"
+)
 
 
 class TestEvents(unittest.TestCase):
@@ -182,10 +191,20 @@ class TestEvents(unittest.TestCase):
         self.assertEqual(bus.ee.listeners(event_name), [])
 
 
+@_ignore_event_scheduler_moved
 class TestEventSchedulerInterface(unittest.TestCase):
     from ovos_utils.events import EventSchedulerInterface
     bus = FakeBus()
-    interface = EventSchedulerInterface(bus=bus, skill_id="test")
+    # class-body instantiation runs at collection/import time, before the
+    # pytest filterwarnings mark above applies to test items -- silence
+    # the deprecated-shim noise locally instead.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="EventSchedulerInterface moved to ovos_bus_client",
+            category=DeprecationWarning,
+        )
+        interface = EventSchedulerInterface(bus=bus, skill_id="test")
 
     def test_00_init(self):
         from ovos_utils.events import EventContainer
@@ -513,6 +532,7 @@ class TestEventContainerOnce(unittest.TestCase):
         self.assertTrue(result)
 
 
+@_ignore_event_scheduler_moved
 class TestEventSchedulerInterfaceExtended(unittest.TestCase):
     """Additional tests for EventSchedulerInterface uncovered methods."""
 

--- a/test/unittests/test_fakebus_intent_topic_bridge.py
+++ b/test/unittests/test_fakebus_intent_topic_bridge.py
@@ -18,7 +18,16 @@ import asyncio
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from ovos_utils.fakebus import AsyncFakeBus, FakeBus, Message, INTENT_COMPAT_TWIN_KEY
+
+# ovos_utils.fakebus.Message is a deprecated shim (use ovos_spec_tools.Message
+# or ovos_bus_client.Message); this module deliberately keeps exercising it
+# for coverage, filtered per-module.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:ovos_utils.fakebus.Message is deprecated:DeprecationWarning"
+)
 
 
 def _run(coro):

--- a/test/unittests/test_fakebus_namespace_migration.py
+++ b/test/unittests/test_fakebus_namespace_migration.py
@@ -4,7 +4,16 @@ import asyncio
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from ovos_utils.fakebus import AsyncFakeBus, FakeBus, Message
+
+# ovos_utils.fakebus.Message is a deprecated shim (use ovos_spec_tools.Message
+# or ovos_bus_client.Message); this module deliberately keeps exercising it
+# for coverage, filtered per-module.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:ovos_utils.fakebus.Message is deprecated:DeprecationWarning"
+)
 
 
 def _run(coro):

--- a/test/unittests/test_lang.py
+++ b/test/unittests/test_lang.py
@@ -20,7 +20,12 @@ import unittest
 import unittest.mock
 from unittest.mock import patch
 
+import pytest
 
+
+@pytest.mark.filterwarnings(
+    "ignore:standardize_lang_tag is deprecated; use 'standardize_lang' from 'ovos_spec_tools' instead:DeprecationWarning"
+)
 class TestStandardizeLangTag(unittest.TestCase):
     """Tests for standardize_lang_tag."""
 
@@ -61,6 +66,9 @@ class TestStandardizeLangTag(unittest.TestCase):
                 standardize_lang_tag("EN", macro=False), "en")
 
 
+@pytest.mark.filterwarnings(
+    "ignore:get_language_dir is deprecated; use 'closest_lang' from 'ovos_spec_tools':DeprecationWarning"
+)
 class TestGetLanguageDir(unittest.TestCase):
     """Tests for get_language_dir."""
 

--- a/test/unittests/test_network_utils.py
+++ b/test/unittests/test_network_utils.py
@@ -2,6 +2,8 @@
 import unittest
 from time import sleep
 
+import pytest
+
 
 class TestNetworkUtils(unittest.TestCase):
     def test_get_network_tests_config(self):
@@ -34,6 +36,7 @@ class TestNetworkUtils(unittest.TestCase):
         self.assertIsInstance(is_connected_http(), bool)
         # TODO
 
+    @pytest.mark.filterwarnings("ignore:use is_connected_http or is_connected_dns:DeprecationWarning")
     def test_is_connected(self):
         from ovos_utils.network_utils import is_connected
         self.assertIsInstance(is_connected(), bool)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

is_connected_dns() opened a raw socket to check reachability and never closed it, leaking a file descriptor on every check — including every failed probe, which is the common case on a flaky network. It's now closed in a finally block, with the return semantics unchanged.

The rest of the roughly 90 warnings were tests deliberately covering deprecated shims — standardize_lang_tag/get_language_dir, ovos_utils.fakebus.Message, EventSchedulerInterface, the dialog module, expand_template — plus a couple of unrelated stdlib/test-fixture ResourceWarnings from unclosed files in the dialog test fixtures. These are now silenced with per-test/class/module pytest.mark.filterwarnings using the specific message text, so the deprecated code paths stay covered but the summary is clean.

Full suite with -W default: ~90 warnings before, 1 after. The one remaining warning is emitted by the currently-installed (unpatched) ovos-bus-client dependency's own session.py at import time, not by anything in this repo — it will clear on its own once that fix (a companion PR already up in ovos-bus-client) is released. 949 passed, 1 skipped, unchanged.