### PR TITLE
fix: floor ovos-spec-tools at the release that ships intent_topics

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -5,6 +5,15 @@ This page tracks user-visible behavior changes since the last stable release,
 list spans `0.9.0a1` through the current HEAD. Newest first. This file resets
 to empty at the next stable release.
 
+## next alpha
+
+- The `ovos-spec-tools` floor moves to `>=1.6.0a2`, the first release whose
+  `intent_topics` module has the shape `ovos_utils.fakebus` imports. The old
+  floor (`>=0.16.1a2`) was satisfied numerically by releases without the
+  module at all, which made ovos-utils unimportable in resolved-but-stale
+  environments — only a real install caught it.
+
+
 ## 0.13.12a1 — closed a leaked DNS-probe socket
 
 `is_connected_dns()` opened a raw socket for its reachability probe and never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "rich-click~=1.7",
     "rich~=13.7",
     "python-dateutil",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.6.0a2",
 ]
 
 [project.urls]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`ovos_utils.fakebus` imports `ovos_spec_tools.intent_topics`, but the dependency floor (`ovos-spec-tools>=0.16.1a2`) predates that module: any environment whose resolver lands on an old-but-floor-satisfying spec-tools (observed via a downstream's stale `<1.0.0` cap resolving spec-tools 0.18.0a1) gets an unimportable ovos-utils, and only a real install catches it. The floor moves to `>=1.6.0a2`, the first release whose `intent_topics` carries the post-refactor shape the import needs — verified by installing exactly the floor version and importing `canonical_intent_topic`.
